### PR TITLE
ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules/
 /public/build/
+/venv
 .probe_cache
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /node_modules/
 /public/build/
-/venv
+venv
+*.pyc
+__pycache__/
 .probe_cache
 .DS_Store


### PR DESCRIPTION
This will help us avoid pushing python installed dependencies to glean-dictionary repo.