### PR TITLE
Add info about the type of metric and expiry date on Metric Detail Page

### DIFF
--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -7,24 +7,24 @@
   function getMetricDocumentationURI(type) {
     const sourceDocs = "https://mozilla.github.io/glean/book/user/metrics/";
     const links = {
-      memory_distribution: `${sourceDocs}memory_distribution.html`,
-      quantity: `${sourceDocs}quantity.html`,
-      custom_distribution: `${sourceDocs}custom_distribution.html`,
-      string_list: `${sourceDocs}string_list.html`,
-      labeled_string: `${sourceDocs}labeled_strings.html`,
-      timespan: `${sourceDocs}timespan.html`,
-      datetime: `${sourceDocs}datetime.html`,
-      string: `${sourceDocs}string.html`,
-      timing_distribution: `${sourceDocs}timing_distribution.html`,
-      boolean: `${sourceDocs}boolean.html`,
-      labeled_counter: `${sourceDocs}labeled_counters.html`,
-      uuid: `${sourceDocs}uuid.html`,
-      counter: `${sourceDocs}counter.html`,
-      event: `${sourceDocs}event.html`,
-      jwe: `${sourceDocs}jwe.html`,
+      memory_distribution: "memory_distribution.html",
+      quantity: "quantity.html",
+      custom_distribution: "custom_distribution.html",
+      string_list: "string_list.html",
+      labeled_string: "labeled_strings.html",
+      timespan: "timespan.html",
+      datetime: "datetime.html",
+      string: "string.html",
+      timing_distribution: "timing_distribution.html",
+      boolean: "boolean.html",
+      labeled_counter: "labeled_counters.html",
+      uuid: "uuid.html",
+      counter: "counter.html",
+      event: "event.html",
+      jwe: "jwe.html",
     };
 
-    return links[type] || sourceDocs;
+    return `${sourceDocs}${links[type]}` || sourceDocs;
   }
 
   function getExpiryInfo(expiry) {
@@ -50,6 +50,8 @@
     <a
       href={getMetricDocumentationURI(metric.type)}
       target="_blank">{metric.type}</a>
+    in
+    <a href={`/apps/${params.app}`}>{params.app}</a>
     that
     {getExpiryInfo(metric.expires)}
   </p>

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -3,9 +3,54 @@
 
   export let params;
   const metricDataPromise = getMetricData(params.app, params.metric);
+
+  function getMetricDocumentationURI(type) {
+    const sourceDocs = "https://mozilla.github.io/glean/book/user/metrics/";
+    const links = {
+      memory_distribution: `${sourceDocs}memory_distribution.html`,
+      quantity: `${sourceDocs}quantity.html`,
+      custom_distribution: `${sourceDocs}custom_distribution.html`,
+      string_list: `${sourceDocs}string_list.html`,
+      labeled_string: `${sourceDocs}labeled_strings.html`,
+      timespan: `${sourceDocs}timespan.html`,
+      datetime: `${sourceDocs}datetime.html`,
+      string: `${sourceDocs}string.html`,
+      timing_distribution: `${sourceDocs}timing_distribution.html`,
+      boolean: `${sourceDocs}boolean.html`,
+      labeled_counter: `${sourceDocs}labeled_counters.html`,
+      uuid: `${sourceDocs}uuid.html`,
+      counter: `${sourceDocs}counter.html`,
+      event: `${sourceDocs}event.html`,
+      jwe: `${sourceDocs}jwe.html`,
+    };
+
+    return links[type] || sourceDocs;
+  }
+
+  function getExpiryInfo(expiry) {
+    if (Date.now() > new Date(expiry)) {
+      return `expired on ${expiry}`;
+    }
+
+    switch (expiry) {
+      case "never":
+        return "never expires";
+      case "expired":
+        return "has already manually expired";
+      default:
+        return `expires on ${expiry}`;
+    }
+  }
 </script>
 
 {#await metricDataPromise then metric}
   <h1>{metric.name}</h1>
   <p>{metric.description}</p>
+  <p>
+    <a
+      href={getMetricDocumentationURI(metric.type)}
+      target="_blank">{metric.type}</a>
+    that
+    {getExpiryInfo(metric.expires)}
+  </p>
 {/await}


### PR DESCRIPTION
Fixes issue #100

Added type of Metric and Expiry Information below the Metric name and description.
The Metric type links to its documentation as well.

Example of ; never expires
![image](https://user-images.githubusercontent.com/59704142/95789119-8e148980-0cfa-11eb-8875-cd59447cd983.png)

Example of : expiry date to come
![image](https://user-images.githubusercontent.com/59704142/95789240-ccaa4400-0cfa-11eb-85bb-cb30f6ea2815.png)

Example of : expiry date gone past
![image](https://user-images.githubusercontent.com/59704142/95789317-f06d8a00-0cfa-11eb-984f-e93a7e1e5761.png)

@wlach your comments are welcome :) 