### PR TITLE
Sort function has no effect on the list of apps

### DIFF
--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -9,7 +9,7 @@
 
   onMount(async () => {
     apps = await fetchJSON(URL);
-    apps.sort((a, b) => (a.app_id > b.app_id ? 1 : -1));
+    apps.sort((a, b) => (a.name > b.name ? 1 : -1));
     filteredApps = apps;
   });
 

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -9,7 +9,7 @@
 
   onMount(async () => {
     apps = await fetchJSON(URL);
-    apps.sort((a, b) => a.app_id > b.app_id);
+    apps.sort((a, b) => a.app_id > b.app_id ? 1 : -1);
     filteredApps = apps;
   });
 

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -9,7 +9,7 @@
 
   onMount(async () => {
     apps = await fetchJSON(URL);
-    apps.sort((a, b) => a.app_id > b.app_id ? 1 : -1);
+    apps.sort((a, b) => (a.app_id > b.app_id ? 1 : -1));
     filteredApps = apps;
   });
 


### PR DESCRIPTION
The callback to the sort function returns a boolean. 

```
 apps = ret.sort((a, b) => a.app_id > b.app_id);
```
It has no effect on the resultant array as shown in this example

```
let arr = [9, 3, 2, 0, 3, 1000, 8, 7, 6, 5, 4, 3];

arr.sort((a, b) => a > b);
// [9, 3, 2, 0, 3, 1000, 8, 7, 6, 5, 4, 3]

```

after updating the callback
```
arr.sort((a, b) => a > b ? 1 : -1)

// [ 0, 2, 3, 3, 3, 4, 5, 6, 7, 8, 9, 1000]
```

It sorts the list of apps based on the app_id in an alphabetical order
As shown here
![Screenshot 2020-10-12 at 10 56 58 PM](https://user-images.githubusercontent.com/19612755/95796244-d71e0b00-0d05-11eb-985b-a55af06be4f0.png)

**before updating the callback, The list was rendered different on both Chrome and Firefox browsers**

- Chrome Browser
![chrome_result](https://user-images.githubusercontent.com/19612755/95796370-2106f100-0d06-11eb-9fd1-8ed30e1a3977.png)

- Firefox Browser
![firefox_result](https://user-images.githubusercontent.com/19612755/95796382-282dff00-0d06-11eb-9d54-96347c5f42e1.png)

**Now It will be rendered same across both browsers now**





