### PR TITLE
Gather ping types from libraries, as well as applications (partially fixes #109)

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-from requests import HTTPError
 import json
 import os
 
 import requests
 import stringcase
+from requests import HTTPError
 
 PROBE_INFO_BASE_URL = "https://probeinfo.telemetry.mozilla.org"
 REPO_URL = PROBE_INFO_BASE_URL + "/glean/repositories"

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -81,6 +81,8 @@ for repo in list(repos):
 
     # Original source of dependency function:
     # https://github.com/mozilla/mozilla-schema-generator/blob/master/mozilla_schema_generator/glean_ping.py
+    ping_data = requests.get(PINGS_URL_TEMPLATE.format(app_name)).json()
+
     try:
         dependencies = requests.get(DEPENDENCIES_URL_TEMPLATE.format(app_name)).json()
 
@@ -94,6 +96,8 @@ for repo in list(repos):
         for library_name in repo.get("library_names", []):
             repos_by_dependency_name[library_name] = repo["name"]
 
+    dependencies = []
+
     for name in dependency_library_names:
         if name in repos_by_dependency_name:
             dependencies.append(repos_by_dependency_name[name])
@@ -102,11 +106,8 @@ for repo in list(repos):
         dependencies = DEFAULT_DEPENDENCIES
 
     for dependency in dependencies:
-        dependency_ping = requests.get(PINGS_URL_TEMPLATE.format(dependency)).json()
-
-    # pings data
-    app_ping = requests.get(PINGS_URL_TEMPLATE.format(app_name)).json()
-    ping_data = {**app_ping, **dependency_ping}
+        dependency_pings = requests.get(PINGS_URL_TEMPLATE.format(dependency)).json()
+        ping_data = {**ping_data, **dependency_pings}
 
     for (ping_name, ping_data) in ping_data.items():
         app_data["pings"].append(

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -82,36 +82,36 @@ for repo in list(repos):
 
     def get_dependencies():
         try:
-            dependencies = requests.get(DEPENDENCIES_URL_TEMPLATE.format(app_name)).json() 
+            dependencies = requests.get(DEPENDENCIES_URL_TEMPLATE.format(app_name)).json()
 
         except HTTPError:
             return default_dependencies
 
-        dependency_library_names = list(dependencies.keys()) 
+        dependency_library_names = list(dependencies.keys())
         repos_by_dependency_name = {}
 
         for repo in repos:
             for library_name in repo.get('library_names', []):
-                repos_by_dependency_name[library_name] = repo['name'] 
+                repos_by_dependency_name[library_name] = repo['name']
 
         dependencies = []
 
         for name in dependency_library_names:
             if name in repos_by_dependency_name:
-                dependencies.append(repos_by_dependency_name[name])               
+                dependencies.append(repos_by_dependency_name[name])
 
         if len(dependencies) == 0:
             return default_dependencies
-        
-        return dependencies 
+
+        return dependencies
 
     app_ping = requests.get(PINGS_URL_TEMPLATE.format(app_name)).json()
-    
-    for dependency in get_dependencies():
-        dependency_ping = requests.get(PINGS_URL_TEMPLATE.format(dependency)).json()        
 
-    ping_data = {**app_ping, **dependency_ping}    
-    
+    for dependency in get_dependencies():
+        dependency_ping = requests.get(PINGS_URL_TEMPLATE.format(dependency)).json()
+
+    ping_data = {**app_ping, **dependency_ping}
+
     for (ping_name, ping_data) in ping_data.items():
         app_data["pings"].append(
             {"name": ping_name, "description": ping_data["history"][-1]["description"]}

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -10,6 +10,7 @@ PROBE_INFO_BASE_URL = "https://probeinfo.telemetry.mozilla.org"
 REPO_URL = PROBE_INFO_BASE_URL + "/glean/repositories"
 PINGS_URL_TEMPLATE = PROBE_INFO_BASE_URL + "/glean/{}/pings"
 METRICS_URL_TEMPLATE = PROBE_INFO_BASE_URL + "/glean/{}/metrics"
+DEPENDENCIES_URL_TEMPLATE= PROBE_INFO_BASE_URL + "/glean/{}/dependencies"
 OUTPUT_DIRECTORY = os.path.join("public", "data")
 
 
@@ -122,3 +123,17 @@ for repo in list(repos):
         )
 
     open(os.path.join(app_dir, "index.json"), "w").write(json.dumps(app_data))
+
+dependencies_data = requests.get(DEPENDENCIES_URL_TEMPLATE.format(app_name)).json()
+
+dependency_library_names = list(dependencies_data.keys())
+repos_by_dependency_name = {}
+
+for dependency_repo in repo_data: 
+    for library_name in dependency_repo.get('library_names', []):
+        repos_by_dependency_name[library_name] = dependency_repo['name']
+
+dependencies_data = []
+for name in dependency_library_names:
+    if name in repos_by_dependency_name:
+        dependencies_data.append(repos_by_dependency_name[name])    

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -94,8 +94,6 @@ for repo in list(repos):
         for library_name in repo.get("library_names", []):
             repos_by_dependency_name[library_name] = repo["name"]
 
-    dependencies = []
-
     for name in dependency_library_names:
         if name in repos_by_dependency_name:
             dependencies.append(repos_by_dependency_name[name])


### PR DESCRIPTION
Hello @wlach ! I am super confused about this issue. :sweat_smile: 

Here I am supposed to collect all metric/ping types. At first look, it seemed I can do that just by removing the [filter](https://github.com/mozilla/glean-dictionary/blob/main/scripts/build-glean-metadata.py#L22) from line 22 in `build-glean-metadata.py` file. I could also make separate lists like applications on the front page of Glean Dictionary prototype. 
But if it was like that, you would not ask to look at Mozilla Schema Generator. 

I am confused about why there is the necessity of using the logic from Schema Generator, how to show them. Surely here you are not looking for just changing the architecture of `build-glean-metadata.py` with self function here? 

It would be really helpful if you would give me some more hints about how to approach issue #109 