### PR TITLE
Avoid formatting tailwind bundle.css file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 public/build/bundle.js
 public/build/bundle.css
 public/data/*
+public/build/public/build/bundle.css
 venv


### PR DESCRIPTION
It took around one and half minute, just to format tailwind bundle.css. 

I think we don't need formatting a minified file.

Here is screen shot.
![Screenshot 2020-10-20 at 8 52 17 AM](https://user-images.githubusercontent.com/19612755/96538563-3c4ba080-12b2-11eb-8133-6b51601b5038.png)
