### PR TITLE
added no-result text for search filter

### DIFF
--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -66,12 +66,21 @@
   </ul>
   <h2>Metrics</h2>
   <FilterInput onChangeText={filterMetrics} />
-  <ul>
-    {#each filteredMetrics as metric}
-      <li>
-        <a href={`/apps/${params.app}/metrics/${metric.name}`}>{metric.name}</a>
-        <i>{metric.description}</i>
-      </li>
-    {/each}
-  </ul>
+  {#if filteredMetrics.length > 0}
+    <ul>
+      {#each filteredMetrics as metric}
+        <li>
+          <a
+            href={`/apps/${params.app}/metrics/${metric.name}`}>{metric.name}</a>
+          <i>{metric.description}</i>
+        </li>
+      {/each}
+    </ul>
+  {:else}
+    <div
+      class="bg-blue-100 border-t border-b border-blue-500 text-blue-700 px-4 py-3"
+      role="alert">
+      <p>Nothing matched your query. :)</p>
+    </div>
+  {/if}
 {/if}


### PR DESCRIPTION
As mentioned #146 a blank page is not appropriate when the search filter matches. Nothing. This PR checks whether there's something in the filter and displays a no result message if found blank.
### Preview
![Screenshot from 2020-10-20 15-26-59](https://user-images.githubusercontent.com/38939048/96600879-5654a580-12e9-11eb-9444-a164cf14c27e.png)
