### PR TITLE
Update Tailwind config to remove PurgeCSS package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3713,40 +3713,6 @@
         }
       }
     },
-    "@fullhuman/postcss-purgecss": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.0.0.tgz",
-      "integrity": "sha512-cvuOgMwIVlfgWcUMqg5p33NbGUxLwMrKtDKkm3QRfOo4PRVNR6+y/xd9OyXTVZiB1bIpKNJ0ZObYPWD3DRQDtw==",
-      "requires": {
-        "postcss": "7.0.32",
-        "purgecss": "^3.0.0"
-      },
-      "dependencies": {
-        "postcss": {
-          "version": "7.0.32",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "@icons/material": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
@@ -22379,47 +22345,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "purgecss": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-3.0.0.tgz",
-      "integrity": "sha512-t3FGCwyX9XWV3ffvnAXTw6Y3Z9kNlcgm14VImNK66xKi5sdqxSA2I0SFYxtmZbAKuIZVckPdazw5iKL/oY/2TA==",
-      "requires": {
-        "commander": "^6.0.0",
-        "glob": "^7.0.0",
-        "postcss": "7.0.32",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
-          "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA=="
-        },
-        "postcss": {
-          "version": "7.0.32",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-          "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
     },
     "q": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "svelte-loader": "2.13.6"
   },
   "dependencies": {
-    "@fullhuman/postcss-purgecss": "^3.0.0",
     "just-throttle": "^1.1.0",
     "lunr": "^2.3.9",
     "node-fetch": "^2.6.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,17 +1,7 @@
-const purgecss = require("@fullhuman/postcss-purgecss")({
-  content: ["./src/**/*.html", "./src/**/*.svelte"],
-
-  whitelistPatterns: [/svelte-/],
-
-  defaultExtractor: (content) => content.match(/[A-Za-z0-9-_:/]+/g) || [],
-});
-
 const postCssImport = require("postcss-import");
 
 const tailwindcss = require("tailwindcss");
 
-const production = !process.env.ROLLUP_WATCH;
-
 module.exports = {
-  plugins: [postCssImport, tailwindcss, ...(production ? [purgecss] : [])],
+  plugins: [postCssImport, tailwindcss],
 };

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,4 @@
-const postCssImport = require("postcss-import");
-
-const tailwindcss = require("tailwindcss");
-
 module.exports = {
-  plugins: [postCssImport, tailwindcss],
+  /* eslint-disable global-require */
+  plugins: [require("postcss-import"), require("tailwindcss")],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,21 +1,5 @@
 const production = !process.env.ROLLUP_WATCH;
 
-const svelteExtractor = (content) => {
-  const regExp = new RegExp(/[A-Za-z0-9-_:/]+/g);
-  const matchedTokens = [];
-  let match = regExp.exec(content);
-
-  while (match) {
-    if (match[0].startsWith("class")) {
-      matchedTokens.push(match[0].substring(6));
-    } else {
-      matchedTokens.push(match[0]);
-    }
-    match = regExp.exec(content);
-  }
-  return matchedTokens;
-};
-
 module.exports = {
   future: {},
   purge: {
@@ -23,7 +7,11 @@ module.exports = {
     enabled: production, // disable purge in dev
     options: {
       whitelist: [/svelte-/],
-      defaultExtractor: svelteExtractor,
+      /* eslint-disable no-unused-vars */
+      defaultExtractor: (content) =>
+        [...content.matchAll(/(?:class:)*([\w\d-/:%.]+)/gm)].map(
+          ([_match, group, ..._rest]) => group
+        ),
     },
   },
   theme: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,18 @@
+const production = !process.env.ROLLUP_WATCH;
+
+module.exports = {
+  future: {},
+  purge: {
+    content: ["./src/**/*.svelte", "./src/**/*.html"],
+    enabled: production, // disable purge in dev
+    options: {
+      whitelist: [/svelte-/],
+      defaultExtractor: (content) => content.match(/[A-Za-z0-9-_:/]+/g) || [],
+    },
+  },
+  theme: {
+    extend: {},
+  },
+  variants: {},
+  plugins: [],
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,21 @@
 const production = !process.env.ROLLUP_WATCH;
 
+const svelteExtractor = (content) => {
+  const regExp = new RegExp(/[A-Za-z0-9-_:/]+/g);
+  const matchedTokens = [];
+  let match = regExp.exec(content);
+
+  while (match) {
+    if (match[0].startsWith("class")) {
+      matchedTokens.push(match[0].substring(6));
+    } else {
+      matchedTokens.push(match[0]);
+    }
+    match = regExp.exec(content);
+  }
+  return matchedTokens;
+};
+
 module.exports = {
   future: {},
   purge: {
@@ -7,7 +23,7 @@ module.exports = {
     enabled: production, // disable purge in dev
     options: {
       whitelist: [/svelte-/],
-      defaultExtractor: (content) => content.match(/[A-Za-z0-9-_:/]+/g) || [],
+      defaultExtractor: svelteExtractor,
     },
   },
   theme: {


### PR DESCRIPTION
- Tailwind [v1.4](https://tailwindcss.com/docs/release-notes#tailwind-css-v1-4) (released April 29th, 2020) and later has built-in PurgeCSS support. We no longer need to install third-party PurgeCSS and set up its configuration. There are [new features](https://tailwindcss.com/docs/release-notes) that we can utilize later by setting up tailwind config 
- What I did:
    - Move purge configuration from postcss to tailwind config
    - Remove @fullhuman/purgeCSS from postcss config and package.json

Looking forward to feedback! Thanks!
