### PR TITLE
Fix incorrect metric description caused by markdown rendering (#190)

### DIFF
--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -1,13 +1,9 @@
 <script>
   import marked from "marked";
 
-  let markdown;
-  export let text = "";
+  export let text;
 </script>
 
-{#if markdown}
-  {@html marked.parseInline(markdown.textContent)}
-{/if}
-<div class="raw-markdown hidden" bind:this={markdown}>
-  <slot>{text}</slot>
-</div>
+<slot>
+  {@html marked.parseInline(text)}
+</slot>

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -95,9 +95,7 @@
       {#each filteredPings as ping}
         <li>
           <a href={`/apps/${app.name}/pings/${ping.name}`}>{ping.name}</a>
-          <i>
-            <Markdown>{ping.description}</Markdown>
-          </i>
+          <i><Markdown text={ping.description} /></i>
         </li>
       {:else}
         <p>Your search didn't match any ping.</p>
@@ -114,9 +112,7 @@
         <li>
           <a
             href={`/apps/${params.app}/metrics/${metric.name}`}>{metric.name}</a>
-          <i>
-            <Markdown>{metric.description}</Markdown>
-          </i>
+          <i><Markdown text={metric.description} /></i>
         </li>
       {:else}
         <p>Your search didn't match any metric.</p>

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -61,7 +61,7 @@
 {#await metricDataPromise then metric}
   <h1>{metric.name}</h1>
   <p>
-    <Markdown>{metric.description}</Markdown>
+    <Markdown text={metric.description} />
   </p>
   <p>
     <a

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -27,7 +27,7 @@
     <tr>
       <td>Description</td>
       <td>
-        <Markdown>{ping.description}</Markdown>
+        <Markdown text={ping.description} />
       </td>
     </tr>
     <tr>
@@ -77,7 +77,7 @@
       <li>
         <a href={`/apps/${params.app}/metrics/${metric.name}`}>{metric.name}</a>
         <i>
-          <Markdown>{metric.description}</Markdown>
+          <Markdown text={metric.description} />
         </i>
       </li>
     {/each}


### PR DESCRIPTION
**Issue #190** 

The bug is caused by the Markdown component currently producing a hidden div that does not update the text data properly after pagination. 


<img width="716" alt="Screen Shot 2020-11-11 at 2 10 35 PM" src="https://user-images.githubusercontent.com/28797553/98874068-5f3f1f80-242e-11eb-8d8b-186d0318a6fe.png">


Specifically, [this code](https://github.com/mozilla/glean-dictionary/blob/4580911e58a23896bb832f9f98ec2740f6954bf0/src/components/Markdown.svelte#L8-L10) will cause the initial rendering of page 1 metric data to persist on the page, even after the page number is changed. To fix this, I removed the hidden div logic and just rendered the text directly. 

@wlach 




### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts
