### PR TITLE
Correcting "includes client identifier" field (fixes #243)

### DIFF
--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -53,7 +53,7 @@
     </tr>
     <tr>
       <td>Includes Client Identifier</td>
-      <td>{ping.client_id ? 'Yes' : 'No'}</td>
+      <td>{ping.include_client_id ? 'Yes' : 'No'}</td>
     </tr>
     <tr>
       <td>


### PR DESCRIPTION
The field for _includes client identifier_ was changed to the correct field `include_client_id`.
![ss](https://user-images.githubusercontent.com/28039334/101977243-20d99200-3c72-11eb-9386-5f1a5ae573ec.png)

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
