### PR TITLE
Initial attempt at using the protocol design system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6108,6 +6108,12 @@
         }
       }
     },
+    "@mozilla-protocol/core": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-13.0.1.tgz",
+      "integrity": "sha512-Wnhvd9VTQ717C4urboBjt4kaeMqgPOgLNKRFaYNBUFQji42a9Vem/qrs++t8NjfLJh9fd0MTz6ejHCSbCPkiBA==",
+      "dev": true
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/core": "^7.12.10",
     "@babel/plugin-transform-runtime": "7.12.10",
     "@babel/preset-env": "^7.12.11",
+    "@mozilla-protocol/core": "^13.0.1",
     "@rollup/plugin-commonjs": "17.0.0",
     "@rollup/plugin-node-resolve": "11.0.1",
     "@rollup/plugin-replace": "^2.3.4",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -87,25 +87,46 @@
   .brand {
     @apply text-gray-100;
   }
+  .logo {
+    background-image: url("https://glean-dictionary.netlify.app/img/glean_logo.png");
+  }
+
+  .c-sub-navigation {
+    background: #f9f9fa;
+    box-shadow: inset 0 10px 2px -10px rgba(29, 17, 51, 0.04),
+      inset 0 10px 4px -10px rgba(9, 32, 77, 0.12),
+      inset 0 10px 3px -10px rgba(29, 17, 51, 0.12);
+  }
 </style>
 
 <Tailwindcss />
-<nav class="flex items-center justify-between flex-wrap bg-blue-800 p-2">
-  <div class="flex items-center flex-shrink-0 mr-6">
-    <a class="brand font-semibold text-xl tracking-tight" href="/">
-      Glean Dictionary
-      <i>Prototype</i>
-    </a>
+
+<div class="mzp-c-navigation mzp-is-sticky">
+  <div class="mzp-c-navigation-l-content">
+    <div class="mzp-c-navigation-container">
+      <div class="mzp-c-navigation-logo">
+        <a class="logo" href="/">Glean Dictionary</a>
+      </div>
+    </div>
+  </div>
+</div>
+<nav class="mzp-c-navigation c-sub-navigation">
+  <div class="mzp-c-navigation-l-content">
+    <div class="mzp-c-navigation-container">
+      <Breadcrumb {links} />
+    </div>
   </div>
 </nav>
-<Breadcrumb {links} />
-
-<div class="container py-4 mx-auto">
-  <svelte:component
-    this={component}
-    bind:params
-    bind:queryString
-    on:updateURL={updateURL} />
-</div>
+<main>
+  <div class="mzp-l-content">
+    <article class="mzp-c-article">
+      <svelte:component
+        this={component}
+        bind:params
+        bind:queryString
+        on:updateURL={updateURL} />
+    </article>
+  </div>
+</main>
 
 <Footer />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -84,9 +84,6 @@
 </script>
 
 <style>
-  .brand {
-    @apply text-gray-100;
-  }
   .logo {
     background-image: url("https://glean-dictionary.netlify.app/img/glean_logo.png");
   }

--- a/src/Tailwindcss.svelte
+++ b/src/Tailwindcss.svelte
@@ -1,3 +1,4 @@
 <style global>
   @import "main.css";
+  @import "@mozilla-protocol/core/protocol/css/protocol.css";
 </style>

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -830,7 +830,9 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
       <div
         style=""
       >
-        <p>
+        <p
+          class="svelte-10zy88m"
+        >
           <span
             class="text-gray-700"
           >
@@ -843,7 +845,7 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
         </p>
          
         <p
-          class="text-gray-600 text-xs ml-2"
+          class="text-gray-600 text-xs ml-2 svelte-10zy88m"
         >
           A JSON string containing any payload properties not present in the schema
         </p>
@@ -854,7 +856,9 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
       <div
         style=""
       >
-        <p>
+        <p
+          class="svelte-10zy88m"
+        >
           <span
             class="text-gray-700"
           >
@@ -872,7 +876,9 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
       <div
         style=""
       >
-        <p>
+        <p
+          class="svelte-10zy88m"
+        >
           <span
             class="text-gray-700"
           >
@@ -885,7 +891,7 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
         </p>
          
         <p
-          class="text-gray-600 text-xs ml-2"
+          class="text-gray-600 text-xs ml-2 svelte-10zy88m"
         >
           The user-visible version of the operating system (e.g. "1.2.3"). If the version detection fails, this metric gets set to \`Unknown\`.
         </p>
@@ -896,7 +902,9 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
       <div
         style=""
       >
-        <p>
+        <p
+          class="svelte-10zy88m"
+        >
           <span
             class="text-gray-700"
           >
@@ -909,7 +917,7 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
         </p>
          
         <p
-          class="text-gray-600 text-xs ml-2"
+          class="text-gray-600 text-xs ml-2 svelte-10zy88m"
         >
           The version of the Glean SDK
         </p>
@@ -922,7 +930,9 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
       <div
         style=""
       >
-        <p>
+        <p
+          class="svelte-10zy88m"
+        >
           <span
             class="text-gray-700"
           >
@@ -935,7 +945,7 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
         </p>
          
         <p
-          class="text-gray-600 text-xs ml-2"
+          class="text-gray-600 text-xs ml-2 svelte-10zy88m"
         >
           The document ID specified in the URI when the client sent this message
         </p>

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -5,7 +5,7 @@ exports[`Storyshots Breadcrumb App Details Page 1`] = `
   class="storybook-snapshot-container"
 >
   <ol
-    class="flex border-b-2 py-2 divide-x "
+    class="flex py-2 divide-x "
   >
     <li
       class="px-2"
@@ -34,7 +34,7 @@ exports[`Storyshots Breadcrumb Apps List Page 1`] = `
   class="storybook-snapshot-container"
 >
   <ol
-    class="flex border-b-2 py-2 divide-x "
+    class="flex py-2 divide-x "
   >
     <li
       class="px-2"
@@ -54,7 +54,7 @@ exports[`Storyshots Breadcrumb Big Query Table Page 1`] = `
   class="storybook-snapshot-container"
 >
   <ol
-    class="flex border-b-2 py-2 divide-x "
+    class="flex py-2 divide-x "
   >
     <li
       class="px-2"
@@ -101,7 +101,7 @@ exports[`Storyshots Breadcrumb Metric Page 1`] = `
   class="storybook-snapshot-container"
 >
   <ol
-    class="flex border-b-2 py-2 divide-x "
+    class="flex py-2 divide-x "
   >
     <li
       class="px-2"
@@ -139,7 +139,7 @@ exports[`Storyshots Breadcrumb Ping Page 1`] = `
   class="storybook-snapshot-container"
 >
   <ol
-    class="flex border-b-2 py-2 divide-x "
+    class="flex py-2 divide-x "
   >
     <li
       class="px-2"

--- a/src/components/Breadcrumb.svelte
+++ b/src/components/Breadcrumb.svelte
@@ -2,7 +2,7 @@
   export let links;
 </script>
 
-<ol class="flex border-b-2 py-2 divide-x {!links.length ? 'hidden' : ''}">
+<ol class="flex py-2 divide-x {!links.length ? 'hidden' : ''}">
   {#each links as link}
     <li class="px-2"><a href={link.url}>{link.name}</a></li>
   {/each}

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -4,42 +4,42 @@
   const rev = "__VERSION__";
 </script>
 
-<style>
-  .glean-footer {
-    @apply flex;
-    @apply items-center;
-    @apply justify-between;
-    @apply px-8;
-    @apply py-4;
-  }
-  .project-links {
-    @apply flex;
-  }
-  .project-links li {
-    @apply ml-2;
-  }
-  .mozilla-logo {
-    @apply text-black;
-  }
-</style>
-
-<footer class="glean-footer">
-  <a class="mozilla-logo" href="https://www.mozilla.org/"><MozillaLogo /></a>
-  <ul class="project-links">
-    <li>
-      <a href="https://www.mozilla.org/privacy/websites/#cookies">Cookies</a>
-    </li>
-    <li>
-      <a
-        href="https://chat.mozilla.org/#/room/#glean-dictionary:mozilla.org">Chat</a>
-    </li>
-    <li>
-      <a href="https://github.com/mozilla/glean-dictionary/issues">Issues</a>
-    </li>
-    <li><a href="https://github.com/mozilla/glean-dictionary">Source</a></li>
-    <li>
-      <span>Source - </span><a
-        href="https://github.com/mozilla/glean-dictionary/tree/{rev}">{rev.substring(0, 10)}</a>
-    </li>
-  </ul>
+<footer class="mzp-c-footer">
+  <div class="mzp-l-content">
+    <nav class="mzp-c-footer-secondary">
+      <div class="mzp-c-footer-primary-logo">
+        <a
+          href="https://www.mozilla.org/"
+          data-link-type="footer"
+          data-link-name="Mozilla"><MozillaLogo /></a>
+      </div>
+      <div class="mzp-c-footer-legal">
+        <ul class="mzp-c-footer-terms">
+          <li>
+            <a
+              href="https://www.mozilla.org/privacy/websites/#cookies">Cookies</a>
+          </li>
+          <li>
+            <a
+              href="https://chat.mozilla.org/#/room/#glean-dictionary:mozilla.org">Chat</a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/mozilla/glean-dictionary/issues">Issues</a>
+          </li>
+          <li>
+            <a href="https://github.com/mozilla/glean-dictionary">Source</a>
+          </li>
+        </ul>
+        <p>
+          Alpha Software - revision
+          <a
+            href="https://github.com/mozilla/glean-dictionary/tree/{rev}">{rev.substring(0, 10)}</a>
+        </p>
+        <p class="mzp-c-footer-license">
+          © 2020 Mozilla and other contributors.
+        </p>
+      </div>
+    </nav>
+  </div>
 </footer>

--- a/src/components/SchemaNode.svelte
+++ b/src/components/SchemaNode.svelte
@@ -4,6 +4,12 @@
   export let parentFields = [];
 </script>
 
+<style>
+  p {
+    margin: 0;
+  }
+</style>
+
 <div style={node.visible ? '' : 'display: none;'}>
   <p>
     <span


### PR DESCRIPTION
This is an initial attempt at styling the site using Mozilla's [protocol design system](https://protocol.mozilla.org/). It's a bit rough right now, but I think it shows potential. I like how using protocol implies a strong association with Mozilla's values, including the [lean](https://www.mozilla.org/en-US/about/policy/lean-data/) and [transparent](https://wiki.mozilla.org/Firefox/Data_Collection) data practices which are behind products like this.

![image](https://user-images.githubusercontent.com/20569/102932997-5dc23780-446f-11eb-8f46-aa3b500096fd.png)

I think for initial phases, using it alongside Tailwind makes sense-- longer term, we may want to move towards extending/using its scss framework (@craigcook recommended looking at this [gpg site](https://github.com/craigcook/gpg-static) for some inspiration)

### Work items (must be addressed before initial merge)

- [ ] Add a proper glean dictionary logo to the top-left of the site header
- [ ] Figure out appropriate heights for the various headers we're using
- [ ] Use a proper footer
- [ ] Fix the BigQuery schema viewer (some conflicts between our own styling and what's provided, it seems)

@craigcook I'd love to hear your thoughts on this, if you have any (no need to rush, I'll be on break after today).
@Iinh (and anyone else reading this) lmk if you have any thoughts too!

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
