### PR TITLE
Add git version information in footer (fixes #295)

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import livereload from "rollup-plugin-livereload";
 import { terser } from "rollup-plugin-terser";
-import { spawn } from "child_process";
+import { spawn, execSync } from "child_process";
 import sveltePreprocess from "svelte-preprocess";
 
 const production = !process.env.ROLLUP_WATCH;
@@ -53,6 +53,9 @@ export default {
     replace({
       __GOOGLE_ANALYTICS_ID__:
         process.env.CONTEXT === "production" && process.env.GOOGLE_ANALYTICS_ID,
+      __GLEAN_VERSION__: execSync("git rev-list HEAD --max-count=1")
+        .toString()
+        .trim(),
     }),
     // If you have external dependencies installed from
     // npm, you'll most likely need these plugins. In

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,7 +53,7 @@ export default {
     replace({
       __GOOGLE_ANALYTICS_ID__:
         process.env.CONTEXT === "production" && process.env.GOOGLE_ANALYTICS_ID,
-      __GLEAN_VERSION__: execSync("git rev-list HEAD --max-count=1")
+      __VERSION__: execSync("git rev-list HEAD --max-count=1")
         .toString()
         .trim(),
     }),

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -1,8 +1,5 @@
 <script>
   import MozillaLogo from "./icons/MozillaLogo.svelte";
-
-  let rev = "__GLEAN_VERSION__";
-  let revLink = `https://github.com/mozilla/glean-dictionary/tree/${rev}`;
 </script>
 
 <style>
@@ -39,7 +36,8 @@
     </li>
     <li><a href="https://github.com/mozilla/glean-dictionary">Source</a></li>
     <li>
-      <span>Glean - revision </span><a href={revLink}>{rev.substring(0, 10)}</a>
+      <span>Source - </span><a
+        href="https://github.com/mozilla/glean-dictionary/tree/__VERSION__">{'__VERSION__'.substring(0, 10)}</a>
     </li>
   </ul>
 </footer>

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -1,5 +1,8 @@
 <script>
   import MozillaLogo from "./icons/MozillaLogo.svelte";
+
+  let rev = "__GLEAN_VERSION__";
+  let revLink = `https://github.com/mozilla/glean-dictionary/tree/${rev}`;
 </script>
 
 <style>
@@ -11,12 +14,10 @@
     @apply py-4;
   }
   .project-links {
-    @apply grid;
-    @apply grid-cols-4;
-    @apply justify-items-center;
-    @apply p-0;
-    @apply m-0;
-    @apply gap-2;
+    @apply flex;
+  }
+  .project-links li {
+    @apply ml-2;
   }
   .mozilla-logo {
     @apply text-black;
@@ -37,5 +38,8 @@
       <a href="https://github.com/mozilla/glean-dictionary/issues">Issues</a>
     </li>
     <li><a href="https://github.com/mozilla/glean-dictionary">Source</a></li>
+    <li>
+      <span>Glean - revision </span><a href={revLink}>{rev.substring(0, 10)}</a>
+    </li>
   </ul>
 </footer>

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -1,5 +1,7 @@
 <script>
   import MozillaLogo from "./icons/MozillaLogo.svelte";
+
+  const rev = "__VERSION__";
 </script>
 
 <style>
@@ -37,7 +39,7 @@
     <li><a href="https://github.com/mozilla/glean-dictionary">Source</a></li>
     <li>
       <span>Source - </span><a
-        href="https://github.com/mozilla/glean-dictionary/tree/__VERSION__">{'__VERSION__'.substring(0, 10)}</a>
+        href="https://github.com/mozilla/glean-dictionary/tree/{rev}">{rev.substring(0, 10)}</a>
     </li>
   </ul>
 </footer>


### PR DESCRIPTION
Solves #295, uses `rollupjs bundler` `replace` plugin and `child_process`, `execSync` to get an attach git rev information in footer.

### View

![Screenshot_2020-12-26 Glean Dictionary Prototype](https://user-images.githubusercontent.com/14317775/103156383-5325dc00-47a8-11eb-904f-2851244520f4.png)

