### PR TITLE
Restyle AppAlert (fixes #316)

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -1,5 +1,148 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Storyshots App Alert Text 1`] = `
+<section
+  class="storybook-snapshot-container"
+>
+  <p
+    class="svelte-sk8cdu"
+  >
+    Error Alert
+  </p>
+   
+  <div
+    class="mzp-c-notification-bar mzp-t-error error svelte-q7l1in"
+  >
+    <svg
+      height="50px"
+      viewBox="0 0 24 24"
+      width="80px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fill-rule="evenodd"
+        stroke="none"
+        stroke-linecap="round"
+        stroke-width="1"
+      >
+        <g
+          stroke="#000000"
+          stroke-width="2"
+          transform="translate(6.000000, 6.000000)"
+        >
+          <path
+            d="M0,0 L12,12"
+          />
+          <path
+            d="M0,12 L12,0"
+          />
+        </g>
+      </g>
+    </svg>
+     
+    <div
+      class="alert-text svelte-q7l1in"
+    >
+      Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.
+    </div>
+  </div>
+   
+  <p
+    class="svelte-sk8cdu"
+  >
+    Warning Alert
+  </p>
+   
+  <div
+    class="mzp-c-notification-bar mzp-t-warning warning svelte-q7l1in"
+  >
+    <svg
+      height="50px"
+      viewBox="0 0 24 24"
+      width="80px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fill-rule="evenodd"
+        stroke="none"
+        stroke-width="1"
+      >
+        <g
+          transform="translate(1.000000, 2.000000)"
+        >
+          <path
+            d="M9.29,1.86 L0.82,16 C0.464641628,16.6153996 0.462519934,17.3731469 0.81442652,17.9905269 C1.16633311,18.6079069 1.81941202,18.9921898 2.53,19 L19.47,19 C20.180588,18.9921898 20.8336669,18.6079069 21.1855735,17.9905269 C21.5374801,17.3731469 21.5353584,16.6153996 21.18,16 L12.71,1.86 C12.3474343,1.26228132 11.6990862,0.897255995 11,0.897255995 C10.3009138,0.897255995 9.65256566,1.26228132 9.29,1.86 Z"
+            stroke="#000000"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <path
+            d="M11,7 L11,11"
+            stroke="#000000"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+          />
+          <circle
+            cx="11"
+            cy="15"
+            fill="#000000"
+            r="1"
+          />
+        </g>
+      </g>
+    </svg>
+     
+    <div
+      class="alert-text svelte-q7l1in"
+    >
+      Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.
+    </div>
+  </div>
+   
+  <p
+    class="svelte-sk8cdu"
+  >
+    Success Alert
+  </p>
+   
+  <div
+    class="mzp-c-notification-bar mzp-t-success success svelte-q7l1in"
+  >
+    <svg
+      height="50px"
+      viewBox="0 0 24 24"
+      width="80px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g
+        fill="none"
+        fill-rule="evenodd"
+        stroke="none"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1"
+      >
+        <polyline
+          points="20 6 9 17 4 12"
+          stroke="#000000"
+          stroke-width="2"
+        />
+      </g>
+    </svg>
+     
+    <div
+      class="alert-text svelte-q7l1in"
+    >
+      Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.
+    </div>
+  </div>
+</section>
+`;
+
 exports[`Storyshots Breadcrumb App Details Page 1`] = `
 <section
   class="storybook-snapshot-container"

--- a/src/components/AppAlert.svelte
+++ b/src/components/AppAlert.svelte
@@ -1,25 +1,44 @@
 <script>
-  export let message = "";
-  export let bgColor;
+  import { fade } from "svelte/transition";
+
+  import WarningIcon from "./icons/WarningIcon.svelte";
+  import ErrorIcon from "./icons/ErrorIcon.svelte";
+  import SuccessIcon from "./icons/SuccessIcon.svelte";
+
+  export let status;
+  export let message;
+
+  const icons = {
+    warning: WarningIcon,
+    error: ErrorIcon,
+    success: SuccessIcon,
+  };
 </script>
 
 <style>
-  .app-alert {
-    width: 100%;
-    padding: $spacing-xs;
-    margin-top: $spacing-sm;
-    margin-bottom: $spacing-sm;
-    box-shadow: 4px 2px 2px $color-light-gray-70;
-
-    p {
-      @include text-title-xs;
-      color: $color-light-gray-10;
+  .mzp-c-notification-bar {
+    display: flex;
+    align-items: center;
+    margin-bottom: $spacing-md;
+    border-radius: 8px;
+    padding: $spacing-md;
+    .alert-text {
+      flex-grow: 1;
+      margin-left: $spacing-sm;
     }
+  }
+  .warning {
+    background-color: $color-yellow-20;
+  }
+  .error {
+    background-color: $color-red-20;
+  }
+  .success {
+    background-color: $color-green-20;
   }
 </style>
 
-<div role="alert">
-  <div class="app-alert" style="background-color: {bgColor}">
-    <p>{message}</p>
-  </div>
+<div class="mzp-c-notification-bar mzp-t-{status} {status}" transition:fade>
+  <svelte:component this={icons[status]} />
+  <div class="alert-text">{message}</div>
 </div>

--- a/src/components/icons/ErrorIcon.svelte
+++ b/src/components/icons/ErrorIcon.svelte
@@ -1,0 +1,20 @@
+<svg
+  width="80px"
+  height="50px"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg">
+  <g
+    stroke="none"
+    stroke-width="1"
+    fill="none"
+    fill-rule="evenodd"
+    stroke-linecap="round">
+    <g
+      transform="translate(6.000000, 6.000000)"
+      stroke="#000000"
+      stroke-width="2">
+      <path d="M0,0 L12,12" />
+      <path d="M0,12 L12,0" />
+    </g>
+  </g>
+</svg>

--- a/src/components/icons/SuccessIcon.svelte
+++ b/src/components/icons/SuccessIcon.svelte
@@ -1,0 +1,15 @@
+<svg
+  width="80px"
+  height="50px"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg">
+  <g
+    stroke="none"
+    stroke-width="1"
+    fill="none"
+    fill-rule="evenodd"
+    stroke-linecap="round"
+    stroke-linejoin="round">
+    <polyline stroke="#000000" stroke-width="2" points="20 6 9 17 4 12" />
+  </g>
+</svg>

--- a/src/components/icons/WarningIcon.svelte
+++ b/src/components/icons/WarningIcon.svelte
@@ -1,0 +1,23 @@
+<svg
+  width="80px"
+  height="50px"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg">
+  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g transform="translate(1.000000, 2.000000)">
+      <path
+        d="M9.29,1.86 L0.82,16 C0.464641628,16.6153996 0.462519934,17.3731469 0.81442652,17.9905269 C1.16633311,18.6079069 1.81941202,18.9921898 2.53,19 L19.47,19 C20.180588,18.9921898 20.8336669,18.6079069 21.1855735,17.9905269 C21.5374801,17.3731469 21.5353584,16.6153996 21.18,16 L12.71,1.86 C12.3474343,1.26228132 11.6990862,0.897255995 11,0.897255995 C10.3009138,0.897255995 9.65256566,1.26228132 9.29,1.86 Z"
+        stroke="#000000"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round" />
+      <path
+        d="M11,7 L11,11"
+        stroke="#000000"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round" />
+      <circle fill="#000000" cx="11" cy="15" r="1" />
+    </g>
+  </g>
+</svg>

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -29,6 +29,11 @@
 </style>
 
 {#await appDataPromise then app}
+  {#if app.prototype}
+    <AppAlert
+      status="warning"
+      message="This application is a prototype. The metrics and pings listed below may contain inconsistencies and testing strings." />
+  {/if}
   <PageTitle text={params.app} />
 
   {#if app.deprecated}
@@ -51,11 +56,6 @@
       </td>
     </tr>
   </table>
-  {#if app.prototype}
-    <AppAlert
-      message="The {params.app} application is a prototype. The metrics and pings listed below may contain inconsistencies and testing strings."
-      bgColor="#808895" />
-  {/if}
 
   <TabGroup active="Metrics">
     <Tab key="Metrics">Metrics</Tab>

--- a/stories/AppAlert.stories.js
+++ b/stories/AppAlert.stories.js
@@ -1,0 +1,9 @@
+import AppAlert from "./AppAlert.svelte";
+
+export default {
+  title: "App Alert",
+};
+
+export const Text = () => ({
+  Component: AppAlert,
+});

--- a/stories/AppAlert.svelte
+++ b/stories/AppAlert.svelte
@@ -1,0 +1,21 @@
+<script>
+  import AppAlert from "../src/components/AppAlert.svelte";
+
+  let alertMessage =
+    "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.";
+</script>
+
+<style>
+  p {
+    @include text-title-xs;
+  }
+</style>
+
+<p>Error Alert</p>
+<AppAlert status="error" message={alertMessage} />
+
+<p>Warning Alert</p>
+<AppAlert status="warning" message={alertMessage} />
+
+<p>Success Alert</p>
+<AppAlert status="success" message={alertMessage} />


### PR DESCRIPTION
This PR restyles AppAlert to fix #316. Right now the only type of Alert we need is "warning" for apps that are prototype, but I also added styling for "success" and "error" to make this component more usable in the future. 

Preview example: https://deploy-preview-324--glean-dictionary-dev.netlify.app/apps/reference-browser
 
### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
