### PR TITLE
BugLink fixes and cleanups

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -429,6 +429,7 @@ exports[`Storyshots Bug Links Bugzilla 1`] = `
   class="storybook-snapshot-container"
 >
   <a
+    class="svelte-12eprqo"
     href="https://bugzilla.mozilla.org/1234"
     target="_blank"
   >
@@ -442,6 +443,7 @@ exports[`Storyshots Bug Links Git Hub 1`] = `
   class="storybook-snapshot-container"
 >
   <a
+    class="svelte-12eprqo"
     href="https://github.com/mozilla-mobile/fenix/issues/1234"
     target="_blank"
   >

--- a/src/components/BugLink.svelte
+++ b/src/components/BugLink.svelte
@@ -2,9 +2,15 @@
   import { getBugLinkTitle } from "../formatters/links";
 
   export let ref;
-  const url = ref.startsWith("http")
+  const url = ref.toString().startsWith("http")
     ? ref
     : `https://bugzilla.mozilla.org/show_bug.cgi?id=${ref}`;
 </script>
+
+<style>
+  a {
+    display: block;
+  }
+</style>
 
 <a href={url} target="_blank"> {getBugLinkTitle(url)} </a>


### PR DESCRIPTION
I missed this when reviewing PR #332 today: review bug could also be an integer, so we need to turn it into a string before "http" checking. 


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
