### PR TITLE
Fix footer jumping around (fixes #322)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -94,12 +94,11 @@
 </script>
 
 <style>
-  html,
-  body {
-    /* keep the  below value the same as footer height 
-       to prevent footer from jumping around */
-    /* stackoverflow.com/questions/21206058/place-footer-at-bottom-only-if-page-is-short/21207313#21207313 */
-    padding-bottom: 350px;
+  .app {
+    min-height: 100vh;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    grid-template-columns: 100%;
   }
 
   .mzp-c-navigation {
@@ -135,37 +134,42 @@
 <svelte:head>
   <title>{title}</title>
 </svelte:head>
-<div class="mzp-c-navigation mzp-is-sticky">
-  <div class="mzp-c-navigation-l-content">
-    <div class="mzp-c-navigation-container">
-      <div class="mzp-c-navigation-logo-glean">
-        <a class="glean-logo" href="/">
-          <img src="/glean_logo.png" alt="Glean Dictionary Logo" /></a>
-        <a href="/"><h5>Dictionary</h5></a>
+
+<div class="app">
+  <header>
+    <div class="mzp-c-navigation mzp-is-sticky">
+      <div class="mzp-c-navigation-l-content">
+        <div class="mzp-c-navigation-container">
+          <div class="mzp-c-navigation-logo-glean">
+            <a class="glean-logo" href="/">
+              <img src="/glean_logo.png" alt="Glean Dictionary Logo" /></a>
+            <a href="/"><h5>Dictionary</h5></a>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
+
+    {#if links.length}
+      <nav class="mzp-c-navigation c-sub-navigation">
+        <div class="mzp-c-navigation-l-content">
+          <div class="mzp-c-navigation-container">
+            <Breadcrumb {links} />
+          </div>
+        </div>
+      </nav>
+    {/if}
+  </header>
+  <main>
+    <div class="mzp-l-content">
+      <article class="mzp-c-article">
+        <svelte:component
+          this={component}
+          bind:params
+          bind:queryString
+          on:updateURL={updateURL} />
+      </article>
+    </div>
+  </main>
+
+  <Footer />
 </div>
-
-{#if links.length}
-  <nav class="mzp-c-navigation c-sub-navigation">
-    <div class="mzp-c-navigation-l-content">
-      <div class="mzp-c-navigation-container">
-        <Breadcrumb {links} />
-      </div>
-    </div>
-  </nav>
-{/if}
-<main>
-  <div class="mzp-l-content">
-    <article class="mzp-c-article">
-      <svelte:component
-        this={component}
-        bind:params
-        bind:queryString
-        on:updateURL={updateURL} />
-    </article>
-  </div>
-</main>
-
-<Footer />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -94,6 +94,14 @@
 </script>
 
 <style>
+  html,
+  body {
+    /* keep the  below value the same as footer height 
+       to prevent footer from jumping around */
+    /* stackoverflow.com/questions/21206058/place-footer-at-bottom-only-if-page-is-short/21207313#21207313 */
+    padding-bottom: 350px;
+  }
+
   .mzp-c-navigation {
     background: $color-black;
     padding-top: $spacing-md;

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -2,6 +2,15 @@
   const rev = "__VERSION__";
 </script>
 
+<style>
+  footer {
+    /* these values need to be equal to body.padding-bottom 
+      in App.svelte to prevent footer from jumping around */
+    height: 350px;
+    margin-top: 350px;
+  }
+</style>
+
 <footer class="mzp-c-footer">
   <div class="mzp-l-content">
     <nav class="mzp-c-footer-secondary">

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -2,15 +2,6 @@
   const rev = "__VERSION__";
 </script>
 
-<style>
-  footer {
-    /* these values need to be equal to body.padding-bottom 
-      in App.svelte to prevent footer from jumping around */
-    height: 350px;
-    margin-top: 350px;
-  }
-</style>
-
 <footer class="mzp-c-footer">
   <div class="mzp-l-content">
     <nav class="mzp-c-footer-secondary">


### PR DESCRIPTION
(sort of) Fixes #322.

This seemingly simple problem turned out to be trickier than I expected. The proposed solution in this PR doesn't _completely_ fix the problem: it worked fine on my laptop screen, but when I tested on a bigger screen (32") and extended the browser window height the problem still persisted.

**On laptop screen**

<img width="903" alt="Screen Shot 2021-01-19 at 2 28 47 PM" src="https://user-images.githubusercontent.com/28797553/105100814-bc74d400-5a62-11eb-8405-0c9e4d3493e3.png">

**On bigger screen**

<img width="1415" alt="gd" src="https://user-images.githubusercontent.com/28797553/105096288-aca5c180-5a5b-11eb-85a7-10766f2390c1.png">


I tried various solutions, and the ones that sort of worked were all a variation of [what @wlach suggested in the original issue](https://stackoverflow.com/a/21207313). I don't have much experience with this, but it seems like even GitHub has this "problem" too, so maybe we're not looking at a problem, but more like an expected footer behavior when the content height is shorter? It's just more prominent on our site because the background color of our footer is black? 

<img width="1404" alt="github" src="https://user-images.githubusercontent.com/28797553/105096128-808a4080-5a5b-11eb-9906-49581e338e68.png">

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
