### PR TITLE
Handle glean-client-info metrics (fixes #248)

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -102,10 +102,14 @@ for app in apps:
 
         metric_type = metric.definition["type"]
         metric_name_snakecase = stringcase.snakecase(metric.identifier)
+        metric_table_name = (
+            f"client_info.{metric_name_snakecase}" if
+            metric.is_client_info else f"metrics.{metric_type}.{metric_name_snakecase}"
+        )
         bigquery_names = dict(
             stable_ping_table_names=stable_ping_table_names,
             metric_type=metric_type,
-            metric_table_name=f"metrics.{metric_type}.{metric_name_snakecase}",
+            metric_table_name=metric_table_name,
             glam_etl_name=etl_snake_case(metric.identifier),
         )
 

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -103,8 +103,9 @@ for app in apps:
         metric_type = metric.definition["type"]
         metric_name_snakecase = stringcase.snakecase(metric.identifier)
         metric_table_name = (
-            f"client_info.{metric_name_snakecase}" if
-            metric.is_client_info else f"metrics.{metric_type}.{metric_name_snakecase}"
+            f"client_info.{metric_name_snakecase}"
+            if metric.is_client_info
+            else f"metrics.{metric_type}.{metric_name_snakecase}"
         )
         bigquery_names = dict(
             stable_ping_table_names=stable_ping_table_names,

--- a/scripts/glean.py
+++ b/scripts/glean.py
@@ -41,7 +41,7 @@ class GleanMetric(GleanObject):
     Represents an individual Glean metric, as defined by probe scraper
     """
 
-    ALL_PINGS_KEYWORDS = ("all-pings", "all_pings")
+    ALL_PINGS_KEYWORDS = ("all-pings", "all_pings", "glean_client_info")
 
     def __init__(self, identifier: str, definition: dict, *, ping_names: List[str] = None):
         self.identifier = identifier
@@ -53,7 +53,7 @@ class GleanMetric(GleanObject):
             [p for d in definition[self.HISTORY_KEY] for p in d.get("send_in_pings", ["metrics"])]
         )
         self.definition["send_in_pings"] = defn_pings
-
+        self.is_client_info = "glean_client_info" in defn_pings
         if ping_names is not None:
             self._update_all_pings(ping_names)
 

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -125,7 +125,7 @@
       </td>
       <td>
         {#each metric.send_in_pings as name}
-          <a href={`/apps/${params.app}/pings/${name}`}> {name} </a>
+          <a href={`/apps/${params.app}/pings/${name}`}> {name} </a>&nbsp;
         {/each}
       </td>
     </tr>

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -125,7 +125,7 @@
       </td>
       <td>
         {#each metric.send_in_pings as name}
-          <a href={`/apps/${params.app}/pings/${name}`}> {name} </a>&nbsp;
+          <a href={`/apps/${params.app}/pings/${name}`}> {name} </a>
         {/each}
       </td>
     </tr>


### PR DESCRIPTION
Glean Client Info metrics are a weird special case:

* they get put into `client_info.<name>` rather than
  `metrics.<type>.<name>` in BigQuery
* they appear in every ping (*not* a "glean_client_info" ping
  as probe-scraper suggests)

This should be solved upstream in probe-scraper, but doing a hacky fix
inside the glean dictionary to get v0 out the door.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
