### PR TITLE
Improve front page loading 

### DIFF
--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -1,5 +1,6 @@
 <script>
   import { onMount } from "svelte";
+  import { fade } from "svelte/transition";
   import { includes } from "lodash";
 
   import { fetchJSON } from "../state/api";
@@ -156,7 +157,7 @@
     </span>
   </div>
 
-  <div class="app-list">
+  <div class="app-list" transition:fade>
     {#each filteredApps as app}
       {#if showDeprecated || !app.deprecated}
         <div class="mzp-c-card mzp-c-card-extra-small has-aspect-3-2" id="card">


### PR DESCRIPTION
This might be a subjective opinion, but it seems like transition from the front page to any other pages is quite choppy/disconcerting due to some delay in application logos loading. To improve this I think we should add fading animation to the app list. 

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
