### PR TITLE
Use `_` instead of `-` to identify metric names (fixes #313)

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -109,7 +109,9 @@ for app in apps:
             glam_etl_name=etl_snake_case(metric.identifier),
         )
 
-        open(os.path.join(app_metrics_dir, f"{metric.identifier}.json"), "w").write(
+        open(
+            os.path.join(app_metrics_dir, f"{metric.identifier.replace('.', '_')}.json"), "w"
+        ).write(
             json.dumps(
                 dict(
                     metric.definition,

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -102,10 +102,15 @@ for app in apps:
 
         metric_type = metric.definition["type"]
         metric_name_snakecase = stringcase.snakecase(metric.identifier)
+        metric_table_name = (
+            f"client_info.{metric_name_snakecase}"
+            if metric.is_client_info
+            else f"metrics.{metric_type}.{metric_name_snakecase}"
+        )
         bigquery_names = dict(
             stable_ping_table_names=stable_ping_table_names,
             metric_type=metric_type,
-            metric_table_name=f"metrics.{metric_type}.{metric_name_snakecase}",
+            metric_table_name=metric_table_name,
             glam_etl_name=etl_snake_case(metric.identifier),
         )
 

--- a/scripts/glean.py
+++ b/scripts/glean.py
@@ -41,7 +41,7 @@ class GleanMetric(GleanObject):
     Represents an individual Glean metric, as defined by probe scraper
     """
 
-    ALL_PINGS_KEYWORDS = ("all-pings", "all_pings")
+    ALL_PINGS_KEYWORDS = ("all-pings", "all_pings", "glean_client_info")
 
     def __init__(self, identifier: str, definition: dict, *, ping_names: List[str] = None):
         self.identifier = identifier
@@ -53,7 +53,7 @@ class GleanMetric(GleanObject):
             [p for d in definition[self.HISTORY_KEY] for p in d.get("send_in_pings", ["metrics"])]
         )
         self.definition["send_in_pings"] = defn_pings
-
+        self.is_client_info = "glean_client_info" in defn_pings
         if ping_names is not None:
             self._update_all_pings(ping_names)
 

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -10,11 +10,10 @@
   import { pageTitle } from "../state/stores";
 
   export let params;
-  let metricName = params.metric;
 
-  const metricDataPromise = getMetricData(params.app, metricName);
+  const metricDataPromise = getMetricData(params.app, params.metric);
 
-  pageTitle.set(`${metricName} | ${params.app} `);
+  pageTitle.set(`${params.metric} | ${params.app} `);
 
   function getGlamUrlTemplate(app) {
     const map = {
@@ -235,5 +234,5 @@
     {/if}
   </table>
 {:catch}
-  <NotFound pageName={metricName} itemType="metric" />
+  <NotFound pageName={params.metric} itemType="metric" />
 {/await}

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -10,7 +10,7 @@
   import { pageTitle } from "../state/stores";
 
   export let params;
-  let metricName = params.metric.replaceAll("-", ".");
+  let metricName = params.metric;
 
   const metricDataPromise = getMetricData(params.app, metricName);
 

--- a/src/state/urls.js
+++ b/src/state/urls.js
@@ -2,7 +2,7 @@ export function getItemURL(appName, itemType, itemName) {
   // workaround servers that incorrectly interpret url resources with a "." in
   // them as having an extension (this is common for metrics) -- the glean
   // schema doesn't allow `-`'s in metrics, so this should be ok
-  return `/apps/${appName}/${itemType}/${itemName.replace(/\./g, "-")}`;
+  return `/apps/${appName}/${itemType}/${itemName.replace(/\./g, "_")}`;
 }
 
 export function getMetricBigQueryURL(appName, pingName, metricName) {

--- a/tests/state.urls.test.js
+++ b/tests/state.urls.test.js
@@ -3,7 +3,7 @@ import { getItemURL } from "../src/state/urls";
 describe("metric URL replacing", () => {
   it("works as expected", () => {
     expect(getItemURL("foo", "metrics", "bar.baz")).toEqual(
-      "/apps/foo/metrics/bar-baz"
+      "/apps/foo/metrics/bar_baz"
     );
   });
 });


### PR DESCRIPTION
Replaced `.`s in metric ulrs with `_`s as a way to establish consistency with the metric names in BigQuery definitions.

Fixes : #313 