### PR TITLE
Fix logo font-size

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -120,6 +120,7 @@
         color: #e0e3e0;
         line-height: 0.7;
         padding-left: $spacing-xs;
+        font-size: 38px;
       }
     }
   }


### PR DESCRIPTION
Something I noticed: because Protocol's headers are responsive, if screen size goes to below 700px, the logo text "Dictionary" gets smaller while "Glean" stays the same size because it is an image and has a fixed width.

**Before**
<img width="590" alt="Screen Shot 2021-01-28 at 8 11 42 AM" src="https://user-images.githubusercontent.com/28797553/106166676-48f95380-6141-11eb-9f95-944e0e2940af.png">

To prevent this, we need to hard code the font size value of "Dictionary" so that it is fixed regardless of screen size.

**After**
<img width="598" alt="Screen Shot 2021-01-28 at 8 11 46 AM" src="https://user-images.githubusercontent.com/28797553/106166950-8cec5880-6141-11eb-9bb8-a015b437ca0e.png">


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
