### PR TITLE
Warn more prominently when a metric is expired

### DIFF
--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -2,6 +2,7 @@
   import { getMetricData } from "../state/api";
   import { getMetricBigQueryURL } from "../state/urls";
   import BugLink from "../components/BugLink.svelte";
+  import AppAlert from "../components/AppAlert.svelte";
   import Markdown from "../components/Markdown.svelte";
   import NotFound from "../components/NotFound.svelte";
   import HelpHoverable from "../components/HelpHoverable.svelte";
@@ -10,7 +11,6 @@
   import WarningIcon from "../components/icons/WarningIcon.svelte";
 
   import { getSearchfoxLink } from "../formatters/searchfox";
-  import Pill from "../components/Pill.svelte";
 
   import { pageTitle } from "../state/stores";
 
@@ -95,10 +95,14 @@
 </style>
 
 {#await metricDataPromise then metric}
-  <PageTitle text={metric.name} />
   {#if isExpired(metric.expires)}
-    <Pill message="Expired" bgColor="#4a5568" />
+    <AppAlert
+      status="warning"
+      message="This metric has expired: it may not be present in the source code, new data will not be ingested into BigQuery, and it will not appear in dashboards." />
   {/if}
+
+  <PageTitle text={metric.name} />
+
   <p>
     <Markdown text={metric.description} />
   </p>


### PR DESCRIPTION
While working on #357, I realized that we should probably be generally much more explicit when a metric is expired. Many things will no longer work as one might expect.

![image](https://user-images.githubusercontent.com/20569/106302229-b0d59a00-6226-11eb-81cc-bbf9119d7a26.png)

Note that I expect to remove the searchbox-specific warning in #357 (I think it's redundant with the changes here), but leaving it in for now.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
