### PR TITLE
Show all metrics in the item list (don't scroll)

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -462,13 +462,13 @@ exports[`Storyshots ItemList Default 1`] = `
   class="storybook-snapshot-container"
 >
   <span
-    class="expire-checkbox svelte-1tphn6y"
+    class="expire-checkbox svelte-1q4bxgx"
   >
     <label
-      class="svelte-1tphn6y"
+      class="svelte-1q4bxgx"
     >
       <input
-        class="svelte-1tphn6y"
+        class="svelte-1q4bxgx"
         type="checkbox"
       />
       
@@ -488,34 +488,34 @@ exports[`Storyshots ItemList Default 1`] = `
   </div>
    
   <div
-    class="item-browser svelte-1tphn6y"
+    class="item-browser svelte-1q4bxgx"
   >
     <table
-      class="mzp-u-data-table svelte-1tphn6y"
+      class="mzp-u-data-table svelte-1q4bxgx"
     >
       <col
-        class="svelte-1tphn6y"
+        class="svelte-1q4bxgx"
         width="35%"
       />
        
       <col
-        class="svelte-1tphn6y"
+        class="svelte-1q4bxgx"
         width="25%"
       />
        
       <col
-        class="svelte-1tphn6y"
+        class="svelte-1q4bxgx"
         width="40%"
       />
        
       <thead
-        class="svelte-1tphn6y"
+        class="svelte-1q4bxgx"
       >
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <th
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             scope="col"
             style="text-align: center;"
           >
@@ -523,7 +523,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             scope="col"
             style="text-align: center;"
           >
@@ -531,7 +531,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             scope="col"
             style="text-align: center;"
           >
@@ -541,19 +541,19 @@ exports[`Storyshots ItemList Default 1`] = `
       </thead>
        
       <tbody
-        class="svelte-1tphn6y"
+        class="svelte-1q4bxgx"
       >
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 0"
               >
                 Test metric 0
@@ -563,14 +563,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -578,10 +578,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 0"
             >
               This is test metric 0
@@ -591,16 +591,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 1"
               >
                 Test metric 1
@@ -610,14 +610,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -625,10 +625,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 1"
             >
               This is test metric 1
@@ -638,16 +638,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 2"
               >
                 Test metric 2
@@ -657,14 +657,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -672,10 +672,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 2"
             >
               This is test metric 2
@@ -685,16 +685,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 3"
               >
                 Test metric 3
@@ -704,14 +704,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -719,10 +719,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 3"
             >
               This is test metric 3
@@ -732,16 +732,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 4"
               >
                 Test metric 4
@@ -751,14 +751,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -766,10 +766,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 4"
             >
               This is test metric 4
@@ -779,16 +779,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 5"
               >
                 Test metric 5
@@ -798,14 +798,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -813,10 +813,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 5"
             >
               This is test metric 5
@@ -826,16 +826,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 6"
               >
                 Test metric 6
@@ -845,14 +845,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -860,10 +860,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 6"
             >
               This is test metric 6
@@ -873,16 +873,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 7"
               >
                 Test metric 7
@@ -892,14 +892,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -907,10 +907,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 7"
             >
               This is test metric 7
@@ -920,16 +920,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 8"
               >
                 Test metric 8
@@ -939,14 +939,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -954,10 +954,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 8"
             >
               This is test metric 8
@@ -967,16 +967,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 9"
               >
                 Test metric 9
@@ -986,14 +986,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1001,10 +1001,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 9"
             >
               This is test metric 9
@@ -1014,16 +1014,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 10"
               >
                 Test metric 10
@@ -1033,14 +1033,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1048,10 +1048,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 10"
             >
               This is test metric 10
@@ -1061,16 +1061,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 11"
               >
                 Test metric 11
@@ -1080,14 +1080,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1095,10 +1095,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 11"
             >
               This is test metric 11
@@ -1108,16 +1108,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 12"
               >
                 Test metric 12
@@ -1127,14 +1127,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1142,10 +1142,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 12"
             >
               This is test metric 12
@@ -1155,16 +1155,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 13"
               >
                 Test metric 13
@@ -1174,14 +1174,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1189,10 +1189,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 13"
             >
               This is test metric 13
@@ -1202,16 +1202,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 14"
               >
                 Test metric 14
@@ -1221,14 +1221,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1236,10 +1236,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 14"
             >
               This is test metric 14
@@ -1249,16 +1249,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 15"
               >
                 Test metric 15
@@ -1268,14 +1268,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1283,10 +1283,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 15"
             >
               This is test metric 15
@@ -1296,16 +1296,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 16"
               >
                 Test metric 16
@@ -1315,14 +1315,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1330,10 +1330,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 16"
             >
               This is test metric 16
@@ -1343,16 +1343,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 17"
               >
                 Test metric 17
@@ -1362,14 +1362,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1377,10 +1377,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 17"
             >
               This is test metric 17
@@ -1390,16 +1390,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 18"
               >
                 Test metric 18
@@ -1409,14 +1409,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1424,10 +1424,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 18"
             >
               This is test metric 18
@@ -1437,16 +1437,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1tphn6y"
+          class="svelte-1q4bxgx"
         >
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <a
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
                 href="/apps/app-name/metrics/Test metric 19"
               >
                 Test metric 19
@@ -1456,14 +1456,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1tphn6y"
+            class="svelte-1q4bxgx"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
             >
               <code
-                class="svelte-1tphn6y"
+                class="svelte-1q4bxgx"
               >
                 metric_type
               </code>
@@ -1471,10 +1471,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1tphn6y"
+            class="description svelte-1q4bxgx"
           >
             <div
-              class="item-property svelte-1tphn6y"
+              class="item-property svelte-1q4bxgx"
               title="This is test metric 19"
             >
               This is test metric 19

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -462,13 +462,13 @@ exports[`Storyshots ItemList Default 1`] = `
   class="storybook-snapshot-container"
 >
   <span
-    class="expire-checkbox svelte-1wy46sp"
+    class="expire-checkbox svelte-1tphn6y"
   >
     <label
-      class="svelte-1wy46sp"
+      class="svelte-1tphn6y"
     >
       <input
-        class="svelte-1wy46sp"
+        class="svelte-1tphn6y"
         type="checkbox"
       />
       
@@ -488,34 +488,34 @@ exports[`Storyshots ItemList Default 1`] = `
   </div>
    
   <div
-    class="item-browser svelte-1wy46sp"
+    class="item-browser svelte-1tphn6y"
   >
     <table
-      class="mzp-u-data-table svelte-1wy46sp"
+      class="mzp-u-data-table svelte-1tphn6y"
     >
       <col
-        class="svelte-1wy46sp"
+        class="svelte-1tphn6y"
         width="35%"
       />
        
       <col
-        class="svelte-1wy46sp"
+        class="svelte-1tphn6y"
         width="25%"
       />
        
       <col
-        class="svelte-1wy46sp"
+        class="svelte-1tphn6y"
         width="40%"
       />
        
       <thead
-        class="svelte-1wy46sp"
+        class="svelte-1tphn6y"
       >
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <th
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             scope="col"
             style="text-align: center;"
           >
@@ -523,7 +523,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             scope="col"
             style="text-align: center;"
           >
@@ -531,7 +531,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             scope="col"
             style="text-align: center;"
           >
@@ -541,685 +541,945 @@ exports[`Storyshots ItemList Default 1`] = `
       </thead>
        
       <tbody
-        class="svelte-1wy46sp"
+        class="svelte-1tphn6y"
       >
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 0"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 0
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 0"
+              >
+                Test metric 0
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 0
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 0"
+            >
+              This is test metric 0
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 1"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 1
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 1"
+              >
+                Test metric 1
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 1
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 1"
+            >
+              This is test metric 1
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 2"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 2
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 2"
+              >
+                Test metric 2
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 2
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 2"
+            >
+              This is test metric 2
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 3"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 3
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 3"
+              >
+                Test metric 3
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 3
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 3"
+            >
+              This is test metric 3
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 4"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 4
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 4"
+              >
+                Test metric 4
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 4
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 4"
+            >
+              This is test metric 4
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 5"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 5
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 5"
+              >
+                Test metric 5
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 5
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 5"
+            >
+              This is test metric 5
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 6"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 6
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 6"
+              >
+                Test metric 6
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 6
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 6"
+            >
+              This is test metric 6
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 7"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 7
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 7"
+              >
+                Test metric 7
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 7
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 7"
+            >
+              This is test metric 7
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 8"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 8
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 8"
+              >
+                Test metric 8
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 8
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 8"
+            >
+              This is test metric 8
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 9"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 9
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 9"
+              >
+                Test metric 9
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 9
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 9"
+            >
+              This is test metric 9
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 10"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 10
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 10"
+              >
+                Test metric 10
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 10
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 10"
+            >
+              This is test metric 10
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 11"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 11
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 11"
+              >
+                Test metric 11
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 11
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 11"
+            >
+              This is test metric 11
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 12"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 12
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 12"
+              >
+                Test metric 12
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 12
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 12"
+            >
+              This is test metric 12
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 13"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 13
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 13"
+              >
+                Test metric 13
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 13
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 13"
+            >
+              This is test metric 13
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 14"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 14
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 14"
+              >
+                Test metric 14
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 14
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 14"
+            >
+              This is test metric 14
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 15"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 15
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 15"
+              >
+                Test metric 15
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 15
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 15"
+            >
+              This is test metric 15
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 16"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 16
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 16"
+              >
+                Test metric 16
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 16
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 16"
+            >
+              This is test metric 16
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 17"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 17
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 17"
+              >
+                Test metric 17
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 17
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 17"
+            >
+              This is test metric 17
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 18"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 18
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 18"
+              >
+                Test metric 18
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 18
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 18"
+            >
+              This is test metric 18
+              
+            </div>
           </td>
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-1tphn6y"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
           >
-            <a
-              class="svelte-1wy46sp"
-              href="/apps/app-name/metrics/Test metric 19"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              Test metric 19
-            </a>
-             
+              <a
+                class="svelte-1tphn6y"
+                href="/apps/app-name/metrics/Test metric 19"
+              >
+                Test metric 19
+              </a>
+               
+            </div>
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-1tphn6y"
             style="text-align: center;"
           >
-            <code
-              class="svelte-1wy46sp"
+            <div
+              class="item-property svelte-1tphn6y"
             >
-              metric_type
-            </code>
+              <code
+                class="svelte-1tphn6y"
+              >
+                metric_type
+              </code>
+            </div>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-1tphn6y"
           >
-            This is test metric 19
-            
+            <div
+              class="item-property svelte-1tphn6y"
+              title="This is test metric 19"
+            >
+              This is test metric 19
+              
+            </div>
           </td>
            
         </tr>

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -462,13 +462,13 @@ exports[`Storyshots ItemList Default 1`] = `
   class="storybook-snapshot-container"
 >
   <span
-    class="expire-checkbox svelte-1q4bxgx"
+    class="expire-checkbox svelte-1s1bzuy"
   >
     <label
-      class="svelte-1q4bxgx"
+      class="svelte-1s1bzuy"
     >
       <input
-        class="svelte-1q4bxgx"
+        class="svelte-1s1bzuy"
         type="checkbox"
       />
       
@@ -488,34 +488,34 @@ exports[`Storyshots ItemList Default 1`] = `
   </div>
    
   <div
-    class="item-browser svelte-1q4bxgx"
+    class="item-browser svelte-1s1bzuy"
   >
     <table
-      class="mzp-u-data-table svelte-1q4bxgx"
+      class="mzp-u-data-table svelte-1s1bzuy"
     >
       <col
-        class="svelte-1q4bxgx"
+        class="svelte-1s1bzuy"
         width="35%"
       />
        
       <col
-        class="svelte-1q4bxgx"
-        width="25%"
+        class="svelte-1s1bzuy"
+        width="20%"
       />
        
       <col
-        class="svelte-1q4bxgx"
-        width="40%"
+        class="svelte-1s1bzuy"
+        width="45%"
       />
        
       <thead
-        class="svelte-1q4bxgx"
+        class="svelte-1s1bzuy"
       >
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <th
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             scope="col"
             style="text-align: center;"
           >
@@ -523,7 +523,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             scope="col"
             style="text-align: center;"
           >
@@ -531,7 +531,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             scope="col"
             style="text-align: center;"
           >
@@ -541,19 +541,19 @@ exports[`Storyshots ItemList Default 1`] = `
       </thead>
        
       <tbody
-        class="svelte-1q4bxgx"
+        class="svelte-1s1bzuy"
       >
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 0"
               >
                 Test metric 0
@@ -563,14 +563,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -578,10 +578,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 0"
             >
               This is test metric 0
@@ -591,16 +591,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 1"
               >
                 Test metric 1
@@ -610,14 +610,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -625,10 +625,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 1"
             >
               This is test metric 1
@@ -638,16 +638,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 2"
               >
                 Test metric 2
@@ -657,14 +657,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -672,10 +672,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 2"
             >
               This is test metric 2
@@ -685,16 +685,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 3"
               >
                 Test metric 3
@@ -704,14 +704,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -719,10 +719,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 3"
             >
               This is test metric 3
@@ -732,16 +732,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 4"
               >
                 Test metric 4
@@ -751,14 +751,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -766,10 +766,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 4"
             >
               This is test metric 4
@@ -779,16 +779,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 5"
               >
                 Test metric 5
@@ -798,14 +798,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -813,10 +813,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 5"
             >
               This is test metric 5
@@ -826,16 +826,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 6"
               >
                 Test metric 6
@@ -845,14 +845,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -860,10 +860,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 6"
             >
               This is test metric 6
@@ -873,16 +873,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 7"
               >
                 Test metric 7
@@ -892,14 +892,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -907,10 +907,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 7"
             >
               This is test metric 7
@@ -920,16 +920,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 8"
               >
                 Test metric 8
@@ -939,14 +939,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -954,10 +954,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 8"
             >
               This is test metric 8
@@ -967,16 +967,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 9"
               >
                 Test metric 9
@@ -986,14 +986,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1001,10 +1001,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 9"
             >
               This is test metric 9
@@ -1014,16 +1014,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 10"
               >
                 Test metric 10
@@ -1033,14 +1033,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1048,10 +1048,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 10"
             >
               This is test metric 10
@@ -1061,16 +1061,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 11"
               >
                 Test metric 11
@@ -1080,14 +1080,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1095,10 +1095,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 11"
             >
               This is test metric 11
@@ -1108,16 +1108,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 12"
               >
                 Test metric 12
@@ -1127,14 +1127,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1142,10 +1142,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 12"
             >
               This is test metric 12
@@ -1155,16 +1155,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 13"
               >
                 Test metric 13
@@ -1174,14 +1174,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1189,10 +1189,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 13"
             >
               This is test metric 13
@@ -1202,16 +1202,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 14"
               >
                 Test metric 14
@@ -1221,14 +1221,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1236,10 +1236,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 14"
             >
               This is test metric 14
@@ -1249,16 +1249,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 15"
               >
                 Test metric 15
@@ -1268,14 +1268,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1283,10 +1283,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 15"
             >
               This is test metric 15
@@ -1296,16 +1296,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 16"
               >
                 Test metric 16
@@ -1315,14 +1315,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1330,10 +1330,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 16"
             >
               This is test metric 16
@@ -1343,16 +1343,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 17"
               >
                 Test metric 17
@@ -1362,14 +1362,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1377,10 +1377,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 17"
             >
               This is test metric 17
@@ -1390,16 +1390,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 18"
               >
                 Test metric 18
@@ -1409,14 +1409,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1424,10 +1424,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 18"
             >
               This is test metric 18
@@ -1437,16 +1437,16 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1q4bxgx"
+          class="svelte-1s1bzuy"
         >
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <a
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
                 href="/apps/app-name/metrics/Test metric 19"
               >
                 Test metric 19
@@ -1456,14 +1456,14 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1q4bxgx"
+            class="svelte-1s1bzuy"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
             >
               <code
-                class="svelte-1q4bxgx"
+                class="svelte-1s1bzuy"
               >
                 metric_type
               </code>
@@ -1471,10 +1471,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1q4bxgx"
+            class="description svelte-1s1bzuy"
           >
             <div
-              class="item-property svelte-1q4bxgx"
+              class="item-property svelte-1s1bzuy"
               title="This is test metric 19"
             >
               This is test metric 19

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -5,7 +5,6 @@
 
   import { getItemURL } from "../state/urls";
 
-  import tippy from "./tippy";
   import Pagination from "./Pagination.svelte";
   import FilterInput from "./FilterInput.svelte";
   import Markdown from "./Markdown.svelte";
@@ -61,10 +60,8 @@
   }
 
   .item-property {
-    height: 24px;
+    height: 36px;
     overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
   }
 
   table {
@@ -91,7 +88,7 @@
         background: rgba($color-link-hover, 0.1);
       }
       .description {
-        @include text-body-sm;
+        @include text-body-xs;
       }
     }
   }

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -62,6 +62,7 @@
   .item-property {
     height: 40px;
     overflow-y: auto;
+    margin: -0.25rem;
   }
 
   table {

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -121,8 +121,8 @@
       <!-- We have to do inline styling here to override Protocol CSS rules -->
       <!-- https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity -->
       <col width="35%" />
-      <col width={itemType === 'metrics' ? '25%' : '65%'} />
-      <col width={itemType === 'metrics' ? '40%' : '0'} />
+      <col width={itemType === 'metrics' ? '20%' : '65%'} />
+      <col width={itemType === 'metrics' ? '45%' : '0'} />
       <thead>
         <tr>
           <th scope="col" style="text-align: center;">Name</th>

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -60,8 +60,8 @@
   }
 
   .item-property {
-    height: 36px;
-    overflow: hidden;
+    height: 40px;
+    overflow-y: auto;
   }
 
   table {

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -5,6 +5,7 @@
 
   import { getItemURL } from "../state/urls";
 
+  import tippy from "./tippy";
   import Pagination from "./Pagination.svelte";
   import FilterInput from "./FilterInput.svelte";
   import Markdown from "./Markdown.svelte";
@@ -54,11 +55,16 @@
 
 <style>
   .item-browser {
-    max-height: 400px;
-    overflow: scroll;
     a {
       text-decoration: none;
     }
+  }
+
+  .item-property {
+    height: 24px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   table {
@@ -133,16 +139,23 @@
         {#each pagedItems as item}
           <tr>
             <td>
-              <a href={getItemURL(appName, itemType, item.name)}>{item.name}</a>
-              {#if isExpired(item.expires)}
-                <Pill message="Expired" bgColor="#4a5568" />
-              {/if}
+              <div class="item-property">
+                <a
+                  href={getItemURL(appName, itemType, item.name)}>{item.name}</a>
+                {#if isExpired(item.expires)}
+                  <Pill message="Expired" bgColor="#4a5568" />
+                {/if}
+              </div>
             </td>
             {#if itemType === 'metrics'}
-              <td style="text-align: center;"><code>{item.type}</code></td>
+              <td style="text-align: center;">
+                <div class="item-property"><code>{item.type}</code></div>
+              </td>
             {/if}
             <td class="description">
-              <Markdown text={item.description} />
+              <div class="item-property" title={item.description}>
+                <Markdown text={item.description} />
+              </div>
             </td>
           </tr>
         {/each}

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -88,7 +88,7 @@
         background: rgba($color-link-hover, 0.1);
       }
       .description {
-        @include text-body-xs;
+        @include text-body-sm;
       }
     }
   }


### PR DESCRIPTION
On request from @tdsmith. I do agree this seems better and more
in line with how other applications work. To prevent the list from
jumping around, I set a maximum height for each table cell (via a div
wrapper for the content). To make the full metric description easily
accessible, added a title tooltip which people can hover over.

![image](https://user-images.githubusercontent.com/20569/106641985-d085fe80-6555-11eb-9c6b-8d17b26a8217.png)

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
