### PR TITLE
[WIP] Add items per page input

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -462,13 +462,28 @@ exports[`Storyshots ItemList Default 1`] = `
   class="storybook-snapshot-container"
 >
   <span
-    class="expire-checkbox svelte-1wy46sp"
+    class="output-control svelte-o23uf0"
   >
     <label
-      class="svelte-1wy46sp"
+      class="svelte-o23uf0"
+    >
+      Show
+        
+      <input
+        class="svelte-o23uf0"
+        min="0"
+        size="4"
+        type="number"
+      />
+      
+        items per page
+    </label>
+     
+    <label
+      class="svelte-o23uf0"
     >
       <input
-        class="svelte-1wy46sp"
+        class="svelte-o23uf0"
         type="checkbox"
       />
       
@@ -488,34 +503,35 @@ exports[`Storyshots ItemList Default 1`] = `
   </div>
    
   <div
-    class="item-browser svelte-1wy46sp"
+    class="item-browser svelte-o23uf0"
+    style="max-height: 1200px;"
   >
     <table
-      class="mzp-u-data-table svelte-1wy46sp"
+      class="mzp-u-data-table svelte-o23uf0"
     >
       <col
-        class="svelte-1wy46sp"
+        class="svelte-o23uf0"
         width="35%"
       />
        
       <col
-        class="svelte-1wy46sp"
+        class="svelte-o23uf0"
         width="25%"
       />
        
       <col
-        class="svelte-1wy46sp"
+        class="svelte-o23uf0"
         width="40%"
       />
        
       <thead
-        class="svelte-1wy46sp"
+        class="svelte-o23uf0"
       >
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <th
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             scope="col"
             style="text-align: center;"
           >
@@ -523,7 +539,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             scope="col"
             style="text-align: center;"
           >
@@ -531,7 +547,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             scope="col"
             style="text-align: center;"
           >
@@ -541,16 +557,16 @@ exports[`Storyshots ItemList Default 1`] = `
       </thead>
        
       <tbody
-        class="svelte-1wy46sp"
+        class="svelte-o23uf0"
       >
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 0"
             >
               Test metric 0
@@ -559,18 +575,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 0
             
@@ -578,13 +594,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 1"
             >
               Test metric 1
@@ -593,18 +609,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 1
             
@@ -612,13 +628,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 2"
             >
               Test metric 2
@@ -627,18 +643,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 2
             
@@ -646,13 +662,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 3"
             >
               Test metric 3
@@ -661,18 +677,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 3
             
@@ -680,13 +696,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 4"
             >
               Test metric 4
@@ -695,18 +711,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 4
             
@@ -714,13 +730,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 5"
             >
               Test metric 5
@@ -729,18 +745,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 5
             
@@ -748,13 +764,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 6"
             >
               Test metric 6
@@ -763,18 +779,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 6
             
@@ -782,13 +798,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 7"
             >
               Test metric 7
@@ -797,18 +813,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 7
             
@@ -816,13 +832,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 8"
             >
               Test metric 8
@@ -831,18 +847,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 8
             
@@ -850,13 +866,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 9"
             >
               Test metric 9
@@ -865,18 +881,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 9
             
@@ -884,13 +900,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 10"
             >
               Test metric 10
@@ -899,18 +915,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 10
             
@@ -918,13 +934,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 11"
             >
               Test metric 11
@@ -933,18 +949,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 11
             
@@ -952,13 +968,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 12"
             >
               Test metric 12
@@ -967,18 +983,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 12
             
@@ -986,13 +1002,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 13"
             >
               Test metric 13
@@ -1001,18 +1017,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 13
             
@@ -1020,13 +1036,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 14"
             >
               Test metric 14
@@ -1035,18 +1051,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 14
             
@@ -1054,13 +1070,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 15"
             >
               Test metric 15
@@ -1069,18 +1085,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 15
             
@@ -1088,13 +1104,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 16"
             >
               Test metric 16
@@ -1103,18 +1119,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 16
             
@@ -1122,13 +1138,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 17"
             >
               Test metric 17
@@ -1137,18 +1153,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 17
             
@@ -1156,13 +1172,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 18"
             >
               Test metric 18
@@ -1171,18 +1187,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 18
             
@@ -1190,13 +1206,13 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1wy46sp"
+          class="svelte-o23uf0"
         >
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
           >
             <a
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
               href="/apps/app-name/metrics/Test metric 19"
             >
               Test metric 19
@@ -1205,18 +1221,18 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="svelte-1wy46sp"
+            class="svelte-o23uf0"
             style="text-align: center;"
           >
             <code
-              class="svelte-1wy46sp"
+              class="svelte-o23uf0"
             >
               metric_type
             </code>
           </td>
            
           <td
-            class="description svelte-1wy46sp"
+            class="description svelte-o23uf0"
           >
             This is test metric 19
             

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -12,7 +12,7 @@
 
   import { isExpired } from "../state/metrics";
 
-  let DEFAULT_ITEMS_PER_PAGE = 20;
+  let itemsPerPage = 20;
 
   export let appName;
   export let items;
@@ -27,10 +27,10 @@
   let currentPage = writable(1);
   setContext("currentPage", currentPage);
 
-  const goToPage = (page) => {
+  const goToPage = (page, perPage = itemsPerPage) => {
     pagedItems =
       filteredItems.length > 0
-        ? chunk([...filteredItems], DEFAULT_ITEMS_PER_PAGE)[page - 1]
+        ? chunk([...filteredItems], perPage)[page - 1]
         : [];
   };
 
@@ -45,7 +45,9 @@
     goToPage(1);
   };
 
-  $: goToPage($currentPage);
+  $: itemsPerPage // eslint-disable-line
+    ? goToPage($currentPage, itemsPerPage)
+    : goToPage($currentPage, 1);
 
   // re-filter items when showExpired changes
   // note on the comma syntax: https://stackoverflow.com/a/56987526
@@ -54,7 +56,6 @@
 
 <style>
   .item-browser {
-    max-height: 400px;
     overflow: scroll;
     a {
       text-decoration: none;
@@ -89,7 +90,7 @@
       }
     }
   }
-  .expire-checkbox {
+  .output-control {
     display: block;
     text-align: right;
     label {
@@ -102,7 +103,12 @@
   <p>Currently, there are no {itemType} available for {items.name}</p>
 {:else}
   {#if itemType === 'metrics'}
-    <span class="expire-checkbox">
+    <span class="output-control">
+      <label>
+        Show
+        <input type="number" bind:value={itemsPerPage} min="0" size="4" />
+        items per page
+      </label>
       <label>
         <input type="checkbox" bind:checked={showExpired} />
         Show expired metrics
@@ -113,7 +119,7 @@
     onChangeText={handleFilter}
     bind:filterText
     placeHolder="Search {itemType}" />
-  <div class="item-browser">
+  <div class="item-browser" style="max-height: {itemsPerPage * 60}px">
     <table class="mzp-u-data-table">
       <!-- We have to do inline styling here to override Protocol CSS rules -->
       <!-- https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity -->
@@ -151,7 +157,5 @@
   </div>
 {/if}
 {#if filteredItems.length}
-  <Pagination
-    totalItems={filteredItems.length}
-    itemsPerPage={DEFAULT_ITEMS_PER_PAGE} />
+  <Pagination totalItems={filteredItems.length} {itemsPerPage} />
 {/if}


### PR DESCRIPTION
Something that I thought about after reading #372: since users have different preferences when it comes to how they want the metric list to look like (more vs less pagination, longer vs shorter list, etc.), we should make the display more customizable. In this PR I experimented with letting users choose how many items they want shown per page. @wlach If you think this could be helpful I'll work on improving the input UI.

<img width="606" alt="Screen Shot 2021-02-05 at 9 50 24 AM" src="https://user-images.githubusercontent.com/28797553/107070088-af145500-6797-11eb-821a-a4ff67e984ca.png">


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
