### PR TITLE
Group variants of applications together

### DIFF
--- a/public/data/.gitignore
+++ b/public/data/.gitignore
@@ -1,5 +1,6 @@
 apps.json
-index.json
+**/index.json
+**/app_ids/*.json
 **/pings/*.json
-**/tables/*.json
+**/tables/**/*.json
 **/metrics/*.json

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -179,10 +179,10 @@ for (app_name, app_group) in app_groups.items():
                 + bq_path
             ).json()
 
-            app_variant_table_dir = os.path.join(app_table_dir, app_id)
+            app_variant_table_dir = os.path.join(app_table_dir, app.app["bq_dataset_family"])
             ping_data["variants"].append(
                 {
-                    "app_id": app.app_id,
+                    "app_id": app_id,
                     "app_channel": app.app.get("app_channel", "release"),
                     "table": stable_ping_table_name,
                 }

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -52,8 +52,9 @@ app_groups = {}
 for app in apps:
     if not app_groups.get(app.app_name):
         app_groups[app.app_name] = {
-            "name": app.app_name,
-            "description": app.app["canonical_app_name"],
+            "app_name": app.app_name,
+            "app_description": app.app["app_description"],
+            "canonical_app_name": app.app["canonical_app_name"],
             "url": app.app["url"],
             "notification_emails": app.app["notification_emails"],
             "app_ids": [],
@@ -62,7 +63,7 @@ for app in apps:
         [
             {
                 "name": app.app_id,
-                "description": app.app["app_description"],
+                "description": app.app.get("description", app.app["app_description"]),
                 "channel": app.app.get("app_channel", "release"),
                 "deprecated": app.app.get("deprecated", False),
             }

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -58,7 +58,7 @@ for app in apps:
         [
             {
                 "name": app.app_id,
-                "description": app.app["description"],
+                "description": app.app["app_description"],
                 "channel": app.app.get("app_channel", "release"),
                 "deprecated": app.app.get("deprecated", False),
             }
@@ -95,10 +95,9 @@ for (app_name, app_group) in app_groups.items():
 
     for app_id in [app["name"] for app in app_group["app_ids"]]:
         app = next(app for app in apps if app.app_id == app_id)
-        app_id_snakecase = stringcase.snakecase(app.app_id)
 
         # information about this app_id
-        open(os.path.join(app_id_dir, f"{app_id_snakecase}.json"), "w").write(json.dumps(app.app))
+        open(os.path.join(app_id_dir, f"{app_id}.json"), "w").write(json.dumps(app.app))
 
         # metrics data
         metrics = app.get_metrics()
@@ -153,7 +152,7 @@ for (app_name, app_group) in app_groups.items():
                 dict(
                     app_id=app.app_id,
                     app_channel=app.app.get("app_channel", "release"),
-                    app_description=app.app["description"],
+                    app_description=app.app["app_description"],
                     bigquery_names=bigquery_names,
                 )
             )
@@ -168,8 +167,8 @@ for (app_name, app_group) in app_groups.items():
 
             # write table description (app variant specific)
             ping_name_snakecase = stringcase.snakecase(ping.identifier)
-            stable_ping_table_name = f"{app_id_snakecase}.{ping_name_snakecase}"
-            live_ping_table_name = f"{app_id_snakecase}_live_v1.{ping_name_snakecase}"
+            stable_ping_table_name = f"{app.app['bq_dataset_family']}.{ping_name_snakecase}"
+            live_ping_table_name = f"{app.app['bq_dataset_family']}_live_v1.{ping_name_snakecase}"
             bq_path = f"{app.app['document_namespace']}/{ping.identifier}/{ping.identifier}.1.bq"
             bq_definition = (
                 "https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/generated-schemas/schemas/"  # noqa
@@ -180,7 +179,7 @@ for (app_name, app_group) in app_groups.items():
                 + bq_path
             ).json()
 
-            app_variant_table_dir = os.path.join(app_table_dir, app_id_snakecase)
+            app_variant_table_dir = os.path.join(app_table_dir, app_id)
             ping_data["variants"].append(
                 {
                     "app_id": app.app_id,

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -133,7 +133,7 @@ for (app_name, app_group) in app_groups.items():
             stable_ping_table_names = []
             for ping in metric.definition["send_in_pings"]:
                 stable_ping_table_names.append(
-                    [ping, f"{app_id_snakecase}.{stringcase.snakecase(ping)}"]
+                    [ping, f"{app.app['bq_dataset_family']}.{stringcase.snakecase(ping)}"]
                 )
 
             metric_type = metric.definition["type"]

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -44,140 +44,188 @@ def etl_snake_case(line: str) -> str:
 
 # First, get the apps we're using
 apps = [app for app in glean.GleanApp.get_apps()]
-
-# Write out a list of apps (for the landing page)
-open(os.path.join(OUTPUT_DIRECTORY, "apps.json"), "w").write(
-    json.dumps(
+app_groups = {}
+for app in apps:
+    if not app_groups.get(app.app_name):
+        app_groups[app.app_name] = {
+            "name": app.app_name,
+            "description": app.app["canonical_app_name"],
+            "url": app.app["url"],
+            "notification_emails": app.app["notification_emails"],
+            "app_ids": [],
+        }
+    app_groups[app.app_name]["app_ids"].extend(
         [
             {
-                k: app.repo[k]
-                for k in ["app_id", "deprecated", "description", "name", "url", "prototype"]
+                "name": app.app_id,
+                "description": app.app["description"],
+                "channel": app.app.get("app_channel", "release"),
+                "deprecated": app.app.get("deprecated", False),
             }
-            for app in apps
         ]
     )
-)
 
-# Write out some metadata for each app (for the app detail page)
-for app in apps:
-    app_name = app.repo_name
+# sort each set of app ids by the following criteria
+# nightly < beta < release < esr
+# non-deprecated < deprecated
+channel_priority = {"nightly": 1, "beta": 2, "release": 3, "esr": 4}
+for app_group in app_groups.values():
+    app_group["app_ids"].sort(key=lambda app_id: channel_priority[app_id["channel"]])
+    app_group["app_ids"].sort(key=lambda app_id: app_id["deprecated"])
+
+# Write out a list of app groups (for the landing page)
+open(os.path.join(OUTPUT_DIRECTORY, "apps.json"), "w").write(json.dumps(list(app_groups.values())))
+
+# Write out some metadata for each app group (for the app detail page)
+for (app_name, app_group) in app_groups.items():
     app_dir = os.path.join(OUTPUT_DIRECTORY, app_name)
-    (app_ping_dir, app_table_dir, app_metrics_dir) = (
-        os.path.join(app_dir, subtype) for subtype in ("pings", "tables", "metrics")
+    (app_id_dir, app_ping_dir, app_table_dir, app_metrics_dir) = (
+        os.path.join(app_dir, subtype) for subtype in ("app_ids", "pings", "tables", "metrics")
     )
-    for directory in (app_ping_dir, app_table_dir, app_metrics_dir):
+    for directory in (app_id_dir, app_ping_dir, app_table_dir, app_metrics_dir):
         os.makedirs(directory, exist_ok=True)
 
-    app_data = dict(app.repo, pings=[], metrics=[])
+    app_data = dict(app_group, pings=[], metrics=[])
 
-    app_id = app.app_id
-    app_id_snakecase = stringcase.snakecase(app_id)
+    app_metrics = {}
+    # keep track of which metric and ping identifiers we have seen so far
+    metric_identifiers_seen = set()
+    ping_identifiers_seen = set()
 
-    # metrics data
-    metrics = app.get_metrics()
-    metric_pings = dict(data=[])
-    for metric in metrics:  # (metric_name, metric_data) in metrics_data.items():
-        # metrics with associated pings
-        metric_pings["data"].append(
-            {
-                "name": metric.identifier,
-                "description": metric.description,
-                "pings": metric.definition["send_in_pings"],
-                "type": metric.definition["type"],
-                "expires": metric.definition["expires"],
-            }
-        )
+    for app_id in [app["name"] for app in app_group["app_ids"]]:
+        app = next(app for app in apps if app.app_id == app_id)
+        app_id_snakecase = stringcase.snakecase(app.app_id)
 
-        app_data["metrics"].append(
-            {
-                "name": metric.identifier,
-                "description": metric.description,
-                "type": metric.definition["type"],
-                "expires": metric.definition["expires"],
-            }
-        )
+        # information about this app_id
+        open(os.path.join(app_id_dir, f"{app_id_snakecase}.json"), "w").write(json.dumps(app.app))
 
-        stable_ping_table_names = []
-        for ping in metric.definition["send_in_pings"]:
-            stable_ping_table_names.append(
-                [ping, f"{app_id_snakecase}.{stringcase.snakecase(ping)}"]
+        # metrics data
+        metrics = app.get_metrics()
+        metric_pings = dict(data=[])
+        for metric in metrics:
+            if metric.identifier not in metric_identifiers_seen:
+                metric_identifiers_seen.add(metric.identifier)
+
+                # metrics with associated pings
+                metric_pings["data"].append(
+                    {
+                        "name": metric.identifier,
+                        "description": metric.description,
+                        "pings": metric.definition["send_in_pings"],
+                        "type": metric.definition["type"],
+                        "expires": metric.definition["expires"],
+                    }
+                )
+
+                app_data["metrics"].append(
+                    {
+                        "name": metric.identifier,
+                        "description": metric.description,
+                        "type": metric.definition["type"],
+                        "expires": metric.definition["expires"],
+                    }
+                )
+
+                app_metrics[metric.identifier] = dict(
+                    metric.definition, name=metric.identifier, repo_url=app.app["url"], variants=[]
+                )
+
+            stable_ping_table_names = []
+            for ping in metric.definition["send_in_pings"]:
+                stable_ping_table_names.append(
+                    [ping, f"{app_id_snakecase}.{stringcase.snakecase(ping)}"]
+                )
+
+            metric_type = metric.definition["type"]
+            metric_name_snakecase = stringcase.snakecase(metric.identifier)
+            metric_table_name = (
+                f"client_info.{metric_name_snakecase}"
+                if metric.is_client_info
+                else f"metrics.{metric_type}.{metric_name_snakecase}"
             )
-
-        metric_type = metric.definition["type"]
-        metric_name_snakecase = stringcase.snakecase(metric.identifier)
-        metric_table_name = (
-            f"client_info.{metric_name_snakecase}"
-            if metric.is_client_info
-            else f"metrics.{metric_type}.{metric_name_snakecase}"
-        )
-        bigquery_names = dict(
-            stable_ping_table_names=stable_ping_table_names,
-            metric_type=metric_type,
-            metric_table_name=metric_table_name,
-            glam_etl_name=etl_snake_case(metric.identifier),
-        )
-
-        open(
-            os.path.join(app_metrics_dir, f"{metric.identifier.replace('.', '_')}.json"), "w"
-        ).write(
-            json.dumps(
+            bigquery_names = dict(
+                stable_ping_table_names=stable_ping_table_names,
+                metric_type=metric_type,
+                metric_table_name=metric_table_name,
+                glam_etl_name=etl_snake_case(metric.identifier),
+            )
+            app_metrics[metric.identifier]["variants"].append(
                 dict(
-                    metric.definition,
-                    name=metric.identifier,
-                    history=metric.definition_history,
+                    app_id=app.app_id,
+                    app_channel=app.app.get("app_channel", "release"),
+                    app_description=app.app["description"],
                     bigquery_names=bigquery_names,
-                    repo_url=app.repo["url"],
-                ),
-                default=_serialize_sets,
-            )
-        )
-
-    for ping in app.get_pings():
-        app_data["pings"].append(
-            {"name": ping.identifier, "description": ping.definition["description"]}
-        )
-
-        # write table description
-        ping_name_snakecase = stringcase.snakecase(ping.identifier)
-        stable_ping_table_name = f"{app_id_snakecase}.{ping_name_snakecase}"
-        live_ping_table_name = f"{app_id_snakecase}_live_v1.{ping_name_snakecase}"
-        bq_path = f"{app_id}/{ping.identifier}/{ping.identifier}.1.bq"
-        bq_definition = (
-            "https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/generated-schemas/schemas/"  # noqa
-            + bq_path
-        )
-        bq_schema = requests.get(
-            "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/generated-schemas/schemas/"  # noqa
-            + bq_path
-        ).json()
-        open(os.path.join(app_table_dir, f"{ping.identifier}.json"), "w").write(
-            json.dumps(
-                dict(
-                    bq_definition=bq_definition,
-                    bq_schema=bq_schema,
-                    live_table=live_ping_table_name,
-                    name=ping.identifier,
-                    stable_table=stable_ping_table_name,
                 )
             )
-        )
 
-        # write ping description
-        open(os.path.join(app_ping_dir, f"{ping.identifier}.json"), "w").write(
-            json.dumps(
-                dict(
-                    ping.definition,
-                    name=ping.identifier,
-                    history=ping.definition_history,
-                    metrics=[
-                        metric
-                        for metric in metric_pings["data"]
-                        if ping.identifier in metric["pings"]
-                    ],
-                    stable_table_name=stable_ping_table_name,
-                ),
-                default=_serialize_sets,
+        for ping in app.get_pings():
+            if ping.identifier not in ping_identifiers_seen:
+                ping_identifiers_seen.add(ping.identifier)
+
+                app_data["pings"].append(
+                    {
+                        "name": ping.identifier,
+                        "description": ping.definition["description"],
+                        "variants": [],
+                    }
+                )
+
+            ping_data = next(pd for pd in app_data["pings"] if pd["name"] == ping.identifier)
+
+            # write table description (app variant specific)
+            ping_name_snakecase = stringcase.snakecase(ping.identifier)
+            stable_ping_table_name = f"{app_id_snakecase}.{ping_name_snakecase}"
+            live_ping_table_name = f"{app_id_snakecase}_live_v1.{ping_name_snakecase}"
+            bq_path = f"{app.app['document_namespace']}/{ping.identifier}/{ping.identifier}.1.bq"
+            bq_definition = (
+                "https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/generated-schemas/schemas/"  # noqa
+                + bq_path
             )
-        )
+            bq_schema = requests.get(
+                "https://raw.githubusercontent.com/mozilla-services/mozilla-pipeline-schemas/generated-schemas/schemas/"  # noqa
+                + bq_path
+            ).json()
 
-    open(os.path.join(app_dir, "index.json"), "w").write(json.dumps(app_data))
+            app_variant_table_dir = os.path.join(app_table_dir, app_id_snakecase)
+            ping_data["variants"].append(app_id_snakecase)
+            os.makedirs(app_variant_table_dir, exist_ok=True)
+            open(os.path.join(app_variant_table_dir, f"{ping.identifier}.json"), "w").write(
+                json.dumps(
+                    dict(
+                        bq_definition=bq_definition,
+                        bq_schema=bq_schema,
+                        live_table=live_ping_table_name,
+                        name=ping.identifier,
+                        stable_table=stable_ping_table_name,
+                        app_id=app_id,
+                    )
+                )
+            )
+
+        # write ping descriptions
+        for ping_data in app_data["pings"]:
+            open(os.path.join(app_ping_dir, f"{ping_data['name']}.json"), "w").write(
+                json.dumps(
+                    dict(
+                        ping_data,
+                        metrics=[
+                            metric
+                            for metric in metric_pings["data"]
+                            if ping_data["name"] in metric["pings"]
+                        ],
+                    ),
+                    default=_serialize_sets,
+                )
+            )
+
+        for metric_data in app_metrics.values():
+            open(
+                os.path.join(app_metrics_dir, f"{metric_data['name'].replace('.', '_')}.json"), "w"
+            ).write(
+                json.dumps(
+                    metric_data,
+                    default=_serialize_sets,
+                )
+            )
+
+        open(os.path.join(app_dir, "index.json"), "w").write(json.dumps(app_data))

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -32,6 +32,10 @@ REV_WORD_BOUND_PAT = re.compile(
 )
 
 
+def get_resource_path(line: str) -> str:
+    return line.replace(".", "_")
+
+
 def etl_snake_case(line: str) -> str:
     """Convert a string into a snake_cased string."""
     # replace non-alphanumeric characters with spaces in the reversed line
@@ -97,7 +101,9 @@ for (app_name, app_group) in app_groups.items():
         app = next(app for app in apps if app.app_id == app_id)
 
         # information about this app_id
-        open(os.path.join(app_id_dir, f"{app_id}.json"), "w").write(json.dumps(app.app))
+        open(os.path.join(app_id_dir, f"{get_resource_path(app_id)}.json"), "w").write(
+            json.dumps(app.app)
+        )
 
         # metrics data
         metrics = app.get_metrics()
@@ -179,7 +185,7 @@ for (app_name, app_group) in app_groups.items():
                 + bq_path
             ).json()
 
-            app_variant_table_dir = os.path.join(app_table_dir, app.app["bq_dataset_family"])
+            app_variant_table_dir = os.path.join(app_table_dir, get_resource_path(app.app_id))
             ping_data["variants"].append(
                 {
                     "app_id": app_id,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,7 @@
   // Pages
   import AppList from "./pages/AppList.svelte";
   import AppDetail from "./pages/AppDetail.svelte";
+  import AppIdDetail from "./pages/AppIdDetail.svelte";
   import PingDetail from "./pages/PingDetail.svelte";
   import MetricDetail from "./pages/MetricDetail.svelte";
   import TableDetail from "./pages/TableDetail.svelte";
@@ -22,7 +23,7 @@
   let title;
 
   afterUpdate(() => {
-    const { app, ping, metric, table } = params;
+    const { app, appId, ping, metric, table } = params;
 
     links = [
       ...(app
@@ -30,6 +31,9 @@
             { url: "/", name: "apps" },
             { url: `/apps/${app}/`, name: app },
           ]
+        : []),
+      ...(appId
+        ? [{ url: `/apps/${app}/app_ids/${appId}/`, name: appId }]
         : []),
       ...(ping ? [{ url: `/apps/${app}/pings/${ping}/`, name: ping }] : []),
       ...(metric
@@ -43,12 +47,8 @@
       ...(table
         ? [
             {
-              url: `/apps/${app}/pings/${table}/`,
+              url: `/apps/${app}/app_ids/${appId}/tables/${table}/`,
               name: table,
-            },
-            {
-              url: `/apps/${app}/tables/${table}/`,
-              name: `${table} table`,
             },
           ]
         : []),
@@ -75,7 +75,8 @@
 
   page("*", parseQuery);
   page("/", setComponent(AppList));
-  page("/apps/:app/tables/:table", setComponent(TableDetail));
+  page("/apps/:app/app_ids/:appId/tables/:table", setComponent(TableDetail));
+  page("/apps/:app/app_ids/:appId", setComponent(AppIdDetail));
   page("/apps/:app/pings/:ping", setComponent(PingDetail));
   page("/apps/:app/metrics/:metric", setComponent(MetricDetail));
   page("/apps/:app", setComponent(AppDetail));

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -143,7 +143,7 @@ exports[`Storyshots App Alert Text 1`] = `
 </section>
 `;
 
-exports[`Storyshots App Variant Selector Text 1`] = `
+exports[`Storyshots App Variant Selector Default 1`] = `
 <section
   class="storybook-snapshot-container"
 >

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -143,6 +143,35 @@ exports[`Storyshots App Alert Text 1`] = `
 </section>
 `;
 
+exports[`Storyshots App Variant Selector Text 1`] = `
+<section
+  class="storybook-snapshot-container"
+>
+  <select>
+    <option
+      value="org.mozilla.fenix"
+    >
+      nightly
+      
+      (
+      org.mozilla.fenix
+      )
+    
+    </option>
+    <option
+      value="org.mozilla.fenix_release"
+    >
+      release
+      
+      (
+      org.mozilla.fenix_release
+      )
+    
+    </option>
+  </select>
+</section>
+`;
+
 exports[`Storyshots Breadcrumb App Details Page 1`] = `
 <section
   class="storybook-snapshot-container"
@@ -570,6 +599,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 0
               </a>
                
+               
             </div>
           </td>
            
@@ -616,6 +646,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 1
               </a>
+               
                
             </div>
           </td>
@@ -664,6 +695,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 2
               </a>
                
+               
             </div>
           </td>
            
@@ -710,6 +742,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 3
               </a>
+               
                
             </div>
           </td>
@@ -758,6 +791,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 4
               </a>
                
+               
             </div>
           </td>
            
@@ -804,6 +838,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 5
               </a>
+               
                
             </div>
           </td>
@@ -852,6 +887,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 6
               </a>
                
+               
             </div>
           </td>
            
@@ -898,6 +934,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 7
               </a>
+               
                
             </div>
           </td>
@@ -946,6 +983,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 8
               </a>
                
+               
             </div>
           </td>
            
@@ -992,6 +1030,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 9
               </a>
+               
                
             </div>
           </td>
@@ -1040,6 +1079,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 10
               </a>
                
+               
             </div>
           </td>
            
@@ -1086,6 +1126,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 11
               </a>
+               
                
             </div>
           </td>
@@ -1134,6 +1175,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 12
               </a>
                
+               
             </div>
           </td>
            
@@ -1180,6 +1222,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 13
               </a>
+               
                
             </div>
           </td>
@@ -1228,6 +1271,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 14
               </a>
                
+               
             </div>
           </td>
            
@@ -1274,6 +1318,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 15
               </a>
+               
                
             </div>
           </td>
@@ -1322,6 +1367,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 16
               </a>
                
+               
             </div>
           </td>
            
@@ -1368,6 +1414,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 17
               </a>
+               
                
             </div>
           </td>
@@ -1416,6 +1463,7 @@ exports[`Storyshots ItemList Default 1`] = `
                 Test metric 18
               </a>
                
+               
             </div>
           </td>
            
@@ -1462,6 +1510,7 @@ exports[`Storyshots ItemList Default 1`] = `
               >
                 Test metric 19
               </a>
+               
                
             </div>
           </td>
@@ -1638,21 +1687,21 @@ exports[`Storyshots Metadata Table Default 1`] = `
   class="storybook-snapshot-container"
 >
   <table
-    class="svelte-op7dfq"
+    class="svelte-e1apn8"
   >
     <col
-      class="svelte-op7dfq"
+      class="svelte-e1apn8"
     />
      
     <col
-      class="svelte-op7dfq"
+      class="svelte-e1apn8"
     />
      
     <tr
-      class="svelte-op7dfq"
+      class="svelte-e1apn8"
     >
       <td
-        class="svelte-op7dfq"
+        class="svelte-e1apn8"
       >
         Source
          
@@ -1680,10 +1729,10 @@ exports[`Storyshots Metadata Table Default 1`] = `
       </td>
        
       <td
-        class="svelte-op7dfq"
+        class="svelte-e1apn8"
       >
         <a
-          class="svelte-op7dfq"
+          class="svelte-e1apn8"
           href="https://github.com/mozilla/testapp"
         >
           https://github.com/mozilla/testapp
@@ -1692,48 +1741,10 @@ exports[`Storyshots Metadata Table Default 1`] = `
     </tr>
     
     <tr
-      class="svelte-op7dfq"
+      class="svelte-e1apn8"
     >
       <td
-        class="svelte-op7dfq"
-      >
-        Application ID
-         
-        <div
-          class="main svelte-11pfwu8"
-        >
-          <span
-            class="svelte-11pfwu8"
-          >
-            <svg
-              class="w-5 inline-block svelte-p1n39r"
-              fill="currentColor"
-              viewBox="0 0 20 20"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                class="svelte-p1n39r"
-                clip-rule="evenodd"
-                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
-                fill-rule="evenodd"
-              />
-            </svg>
-          </span>
-        </div>
-      </td>
-       
-      <td
-        class="svelte-op7dfq"
-      >
-        org.mozilla.testapp
-      </td>
-    </tr>
-    
-    <tr
-      class="svelte-op7dfq"
-    >
-      <td
-        class="svelte-op7dfq"
+        class="svelte-e1apn8"
       >
         Notification Emails
          
@@ -1761,13 +1772,13 @@ exports[`Storyshots Metadata Table Default 1`] = `
       </td>
        
       <td
-        class="svelte-op7dfq"
+        class="svelte-e1apn8"
       >
         <div
-          class="svelte-op7dfq"
+          class="svelte-e1apn8"
         >
           <a
-            class="svelte-op7dfq"
+            class="svelte-e1apn8"
             href="mailto:test@mozilla.com"
           >
             test@mozilla.com

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -594,9 +594,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 0"
+                href="/apps/app-name/metrics/test metric 0"
               >
-                Test metric 0
+                test metric 0
               </a>
                
                
@@ -642,9 +642,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 1"
+                href="/apps/app-name/metrics/test metric 1"
               >
-                Test metric 1
+                test metric 1
               </a>
                
                
@@ -690,9 +690,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 2"
+                href="/apps/app-name/metrics/test metric 2"
               >
-                Test metric 2
+                test metric 2
               </a>
                
                
@@ -738,9 +738,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 3"
+                href="/apps/app-name/metrics/test metric 3"
               >
-                Test metric 3
+                test metric 3
               </a>
                
                
@@ -786,9 +786,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 4"
+                href="/apps/app-name/metrics/test metric 4"
               >
-                Test metric 4
+                test metric 4
               </a>
                
                
@@ -834,9 +834,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 5"
+                href="/apps/app-name/metrics/test metric 5"
               >
-                Test metric 5
+                test metric 5
               </a>
                
                
@@ -882,9 +882,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 6"
+                href="/apps/app-name/metrics/test metric 6"
               >
-                Test metric 6
+                test metric 6
               </a>
                
                
@@ -930,9 +930,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 7"
+                href="/apps/app-name/metrics/test metric 7"
               >
-                Test metric 7
+                test metric 7
               </a>
                
                
@@ -978,9 +978,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 8"
+                href="/apps/app-name/metrics/test metric 8"
               >
-                Test metric 8
+                test metric 8
               </a>
                
                
@@ -1026,9 +1026,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 9"
+                href="/apps/app-name/metrics/test metric 9"
               >
-                Test metric 9
+                test metric 9
               </a>
                
                
@@ -1074,9 +1074,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 10"
+                href="/apps/app-name/metrics/test metric 10"
               >
-                Test metric 10
+                test metric 10
               </a>
                
                
@@ -1122,9 +1122,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 11"
+                href="/apps/app-name/metrics/test metric 11"
               >
-                Test metric 11
+                test metric 11
               </a>
                
                
@@ -1170,9 +1170,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 12"
+                href="/apps/app-name/metrics/test metric 12"
               >
-                Test metric 12
+                test metric 12
               </a>
                
                
@@ -1218,9 +1218,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 13"
+                href="/apps/app-name/metrics/test metric 13"
               >
-                Test metric 13
+                test metric 13
               </a>
                
                
@@ -1266,9 +1266,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 14"
+                href="/apps/app-name/metrics/test metric 14"
               >
-                Test metric 14
+                test metric 14
               </a>
                
                
@@ -1314,9 +1314,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 15"
+                href="/apps/app-name/metrics/test metric 15"
               >
-                Test metric 15
+                test metric 15
               </a>
                
                
@@ -1362,9 +1362,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 16"
+                href="/apps/app-name/metrics/test metric 16"
               >
-                Test metric 16
+                test metric 16
               </a>
                
                
@@ -1410,9 +1410,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 17"
+                href="/apps/app-name/metrics/test metric 17"
               >
-                Test metric 17
+                test metric 17
               </a>
                
                
@@ -1458,9 +1458,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 18"
+                href="/apps/app-name/metrics/test metric 18"
               >
-                Test metric 18
+                test metric 18
               </a>
                
                
@@ -1506,9 +1506,9 @@ exports[`Storyshots ItemList Default 1`] = `
             >
               <a
                 class="svelte-1s1bzuy"
-                href="/apps/app-name/metrics/Test metric 19"
+                href="/apps/app-name/metrics/test metric 19"
               >
-                Test metric 19
+                test metric 19
               </a>
                
                

--- a/src/components/AppVariantSelector.svelte
+++ b/src/components/AppVariantSelector.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  export let variants = [];
+  export let selectedAppVariant = variants[0];
+  let selectedAppId;
+
+  const dispatch = createEventDispatcher();
+
+  const change = () => {
+    selectedAppVariant = variants.find((v) => v.app_id === selectedAppId);
+
+    dispatch("change");
+  };
+</script>
+
+<!-- svelte-ignore a11y-no-onchange -->
+<select bind:value={selectedAppId} on:change={change}>
+  {#each variants as variant}
+    <option value={variant.app_id}>
+      {variant.app_channel}
+      ({variant.app_id})
+    </option>
+  {/each}
+</select>

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -18,6 +18,7 @@
   export let items;
   export let itemType;
 
+  export let showFilter = true;
   export let filterText = "";
 
   let showExpired = false;
@@ -118,10 +119,12 @@
       </label>
     </span>
   {/if}
-  <FilterInput
-    onChangeText={handleFilter}
-    bind:filterText
-    placeHolder="Search {itemType}" />
+  {#if showFilter}
+    <FilterInput
+      onChangeText={handleFilter}
+      bind:filterText
+      placeHolder="Search {itemType}" />
+  {/if}
   <div class="item-browser">
     <table class="mzp-u-data-table">
       <!-- We have to do inline styling here to override Protocol CSS rules -->
@@ -147,6 +150,9 @@
                   href={getItemURL(appName, itemType, item.name)}>{item.name}</a>
                 {#if isExpired(item.expires)}
                   <Pill message="Expired" bgColor="#4a5568" />
+                {/if}
+                {#if item.deprecated}
+                  <Pill message="Deprecated" bgColor="#4a5568" />
                 {/if}
               </div>
             </td>

--- a/src/components/MetadataTable.svelte
+++ b/src/components/MetadataTable.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { isUndefined } from "lodash";
+  import { isNull, isUndefined } from "lodash";
   import HelpHoverable from "./HelpHoverable.svelte";
 
   export let appName = "";
@@ -20,7 +20,7 @@
   <col />
   <col />
   {#each schema as schemaEntry}
-    {#if !isUndefined(item[schemaEntry.id])}
+    {#if !isUndefined(item[schemaEntry.id]) && !isNull(item[schemaEntry.id])}
       <tr>
         <td>
           {schemaEntry.title}

--- a/src/components/MetadataTable.svelte
+++ b/src/components/MetadataTable.svelte
@@ -41,6 +41,12 @@
                   href={format(ref, schemaEntry.linkFormatter)}>{format(ref, schemaEntry.valueFormatter)}</a>
               </div>
             {/each}
+          {:else if schemaEntry.type === 'list'}
+            <ul>
+              {#each item[schemaEntry.id] as ref}
+                <li>{ref}</li>
+              {/each}
+            </ul>
           {:else}{format(item[schemaEntry.id], schemaEntry.valueFormatter)}{/if}
         </td>
       </tr>

--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -11,19 +11,13 @@ const REQUIRED_METRIC_PARAMS_DOCS =
   "https://mozilla.github.io/glean/book/user/metric-parameters.html#required-metric-parameters";
 const OPTIONAL_METRIC_PARAMS_DOCS =
   "https://mozilla.github.io/glean/book/user/metric-parameters.html#optional-metric-parameters";
+
 export const APPLICATION_DEFINITION_SCHEMA = [
   {
     title: "Source",
     id: "url",
     type: "link",
     helpText: "Where the source code for this application lives.",
-  },
-  {
-    title: "Application ID",
-    id: "app_id",
-    type: "value",
-    helpText:
-      "The app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or in the app's Glean initialization call (for other platforms). For applicable platforms, you should be able to construct an app store URL from this value.",
   },
   {
     title: "Notification Emails",
@@ -34,6 +28,26 @@ export const APPLICATION_DEFINITION_SCHEMA = [
     linkFormatter: getEmailLink,
   },
 ];
+
+export const APPLICATION_ID_DEFINITION_SCHEMA = [
+  {
+    title: "Channel",
+    id: "app_channel",
+    type: "value",
+    helpText:
+      "Release channel that this application id corresponds to (release, beta, nightly, or esr).",
+    valueFormatter: (item) => item.channel || "release",
+  },
+  {
+    title: "Dependencies",
+    id: "dependencies",
+    type: "list",
+    helpText:
+      "List of library dependencies that this application id depends on.",
+    valueFormatter: (item) => item.join(", "),
+  },
+];
+
 export const METRIC_DEFINITION_SCHEMA = [
   {
     title: "Source",

--- a/src/main.scss
+++ b/src/main.scss
@@ -15,6 +15,7 @@
     td {
       border: 1px solid $color-light-gray-30;
       padding: 0.5rem;
+      vertical-align: top;
     }
   }
 }

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -43,6 +43,7 @@
   <TabGroup active="Metrics">
     <Tab key="Metrics">Metrics</Tab>
     <Tab key="Pings">Pings</Tab>
+    <Tab key="Application IDs">Application IDs</Tab>
 
     <TabContent key="Pings">
       <ItemList itemType="pings" items={app.pings} appName={app.name} />
@@ -50,6 +51,14 @@
 
     <TabContent key="Metrics">
       <ItemList itemType="metrics" items={app.metrics} appName={app.name} />
+    </TabContent>
+
+    <TabContent key="Application IDs">
+      <ItemList
+        itemType="app_ids"
+        items={app.app_ids}
+        appName={app.name}
+        showFilter={false} />
     </TabContent>
   </TabGroup>
 {:catch}

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -28,12 +28,12 @@
       status="warning"
       message="This application is a prototype. The metrics and pings listed below may contain inconsistencies and testing strings." />
   {/if}
-  <PageTitle text={params.app} />
+  <PageTitle text={app.canonical_app_name} />
 
   {#if app.deprecated}
     <Pill message="Deprecated" bgColor="#4a5568" />
   {/if}
-  <p>{app.description}</p>
+  <p>{app.app_description}</p>
 
   <MetadataTable
     appName={params.app}
@@ -46,18 +46,18 @@
     <Tab key="Application IDs">Application IDs</Tab>
 
     <TabContent key="Pings">
-      <ItemList itemType="pings" items={app.pings} appName={app.name} />
+      <ItemList itemType="pings" items={app.pings} appName={app.app_name} />
     </TabContent>
 
     <TabContent key="Metrics">
-      <ItemList itemType="metrics" items={app.metrics} appName={app.name} />
+      <ItemList itemType="metrics" items={app.metrics} appName={app.app_name} />
     </TabContent>
 
     <TabContent key="Application IDs">
       <ItemList
         itemType="app_ids"
         items={app.app_ids}
-        appName={app.name}
+        appName={app.app_name}
         showFilter={false} />
     </TabContent>
   </TabGroup>

--- a/src/pages/AppIdDetail.svelte
+++ b/src/pages/AppIdDetail.svelte
@@ -1,0 +1,46 @@
+<script>
+  import { getAppIdData } from "../state/api";
+
+  import { APPLICATION_ID_DEFINITION_SCHEMA } from "../data/schemas";
+  import MetadataTable from "../components/MetadataTable.svelte";
+  import Pill from "../components/Pill.svelte";
+  import PageTitle from "../components/PageTitle.svelte";
+  import { pageTitle } from "../state/stores";
+
+  export let params;
+
+  function setTitle(appId, app) {
+    pageTitle.set(`${appId.app_id} | ${app}`);
+  }
+
+  const appIdDataPromise = getAppIdData(params.app, params.appId).then(
+    (appId) => {
+      setTitle(appId, params.app);
+      return appId;
+    }
+  );
+
+  setTitle(params.appId, params.app);
+</script>
+
+<style>
+  @import "../main.scss";
+  h2 {
+    @include text-title-xs;
+  }
+</style>
+
+{#await appIdDataPromise then appId}
+  <PageTitle text={appId.app_id} />
+  <p>{appId.description}</p>
+  {#if appId.deprecated}
+    <Pill message="Deprecated" bgColor="#4a5568" />
+  {/if}
+
+  <h2>Metadata</h2>
+
+  <MetadataTable
+    appName={params.app}
+    item={appId}
+    schema={APPLICATION_ID_DEFINITION_SCHEMA} />
+{/await}

--- a/src/pages/AppIdDetail.svelte
+++ b/src/pages/AppIdDetail.svelte
@@ -32,7 +32,9 @@
 
 {#await appIdDataPromise then appId}
   <PageTitle text={appId.app_id} />
-  <p>{appId.description}</p>
+  {#if appId.description}
+    <p>{appId.description}</p>
+  {/if}
   {#if appId.deprecated}
     <Pill message="Deprecated" bgColor="#4a5568" />
   {/if}

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -16,12 +16,20 @@
 
   onMount(async () => {
     apps = await fetchJSON(URL);
-    apps.sort((a, b) => (a.name > b.name ? 1 : -1));
+    apps.sort((a, b) =>
+      a.canonical_app_name.toLowerCase() > b.canonical_app_name.toLowerCase()
+        ? 1
+        : -1
+    );
     filteredApps = apps;
   });
 
   function filterApps(filterText) {
-    filteredApps = apps.filter((appItem) => appItem.name.includes(filterText));
+    filteredApps = apps.filter((appItem) =>
+      appItem.canonical_app_name
+        .toLowerCase()
+        .includes(filterText.toLowerCase())
+    );
   }
   let showDeprecated = false;
 
@@ -162,29 +170,29 @@
         <div class="mzp-c-card mzp-c-card-extra-small has-aspect-3-2" id="card">
           <a
             class="mzp-c-card-block-link"
-            href="/apps/{app.name}"
+            href="/apps/{app.app_name}"
             id="media-block">
             <div class="mzp-c-card-media-wrapper" id="media-wrapper">
               <img
                 class="mzp-c-card-imgage"
-                src={getAppLogo(app.name)}
-                alt="${app.name} Logo"
+                src={getAppLogo(app.app_name)}
+                alt="${app.canonical_app_name} Logo"
                 id="logo-img" />
-              {#if isPlatform(app.description)}
+              {#if isPlatform(app.app_description)}
                 <div class="corner-flag" />
                 <img
                   class="platform-logo"
-                  src={getPlatformLogo(app.description)}
+                  src={getPlatformLogo(app.app_description)}
                   alt="Platform Logo" />
               {/if}
             </div>
             <div class="mzp-c-card-content">
-              <h2 class="mzp-c-card-title">{app.name}</h2>
+              <h2 class="mzp-c-card-title">{app.canonical_app_name}</h2>
               {#if app.deprecated}
                 <Pill message="Deprecated" bgColor="#4a5568" />
               {/if}
               <p class="mzp-c-card-meta" id="card-description">
-                {app.description}
+                {app.app_description}
               </p>
             </div>
           </a>

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -12,7 +12,7 @@
   } from "../data/schemas";
   import { getMetricData } from "../state/api";
   import { pageTitle } from "../state/stores";
-  import { getMetricBigQueryURL } from "../state/urls";
+  import { getBigQueryURL } from "../state/urls";
 
   import { isExpired } from "../state/metrics";
 
@@ -147,12 +147,12 @@
             <div>
               In
               <a
-                href={getMetricBigQueryURL(params.app, selectedAppVariant.app_id, sendInPing)}>{tableName}</a>
+                href={getBigQueryURL(params.app, selectedAppVariant.app_id, sendInPing)}>{tableName}</a>
               <!-- Skip search string for event metrics as we can't directly lookup the columns in events tables -->
               {#if selectedAppVariant.bigquery_names.metric_type !== 'event'}
                 as
                 <a
-                  href={getMetricBigQueryURL(params.app, selectedAppVariant.app_id, sendInPing, selectedAppVariant.bigquery_names.metric_table_name)}>
+                  href={getBigQueryURL(params.app, selectedAppVariant.app_id, sendInPing, selectedAppVariant.bigquery_names.metric_table_name)}>
                   {selectedAppVariant.bigquery_names.metric_table_name}
                 </a>
               {/if}

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -2,6 +2,8 @@
   import { getPingData } from "../state/api";
   import { pageTitle } from "../state/stores";
 
+  import AppVariantSelector from "../components/AppVariantSelector.svelte";
+  import HelpHoverable from "../components/HelpHoverable.svelte";
   import ItemList from "../components/ItemList.svelte";
   import MetadataTable from "../components/MetadataTable.svelte";
   import NotFound from "../components/NotFound.svelte";
@@ -10,13 +12,21 @@
   import { PING_SCHEMA } from "../data/schemas";
 
   export let params;
-  const pingDataPromise = getPingData(params.app, params.ping);
+  let selectedAppVariant;
+  const pingDataPromise = getPingData(params.app, params.ping).then(
+    (pingData) => {
+      [selectedAppVariant] = pingData.variants;
+      return pingData;
+    }
+  );
 
   pageTitle.set(`${params.ping} | ${params.app}`);
 </script>
 
 <style>
   @import "../main.scss";
+
+  @include metadata-table;
   h2 {
     @include text-title-xs;
   }
@@ -27,13 +37,34 @@
   <p>
     <Markdown text={ping.description} />
   </p>
-  <p>
-    It is represented in BigQuery as
-    <a
-      href={`/apps/${params.app}/tables/${params.ping}`}>{ping.stable_table_name}</a>.
-  </p>
+
   <h2>Metadata</h2>
   <MetadataTable appName={params.app} item={ping} schema={PING_SCHEMA} />
+
+  <h2>Access</h2>
+
+  {#if ping.variants.length > 1}
+    <AppVariantSelector bind:selectedAppVariant variants={ping.variants} />
+  {/if}
+
+  {#if selectedAppVariant}
+    <table>
+      <col />
+      <col />
+      <tr>
+        <td>
+          BigQuery
+          <HelpHoverable
+            content={'The BigQuery representation of this ping.'} />
+        </td>
+        <td>
+          <a
+            href={`/apps/${params.app}/app_ids/${selectedAppVariant.app_id}/tables/${params.ping}`}>{selectedAppVariant.table}</a>
+        </td>
+      </tr>
+    </table>
+  {/if}
+
   <h2>Metrics</h2>
   <ItemList itemType="metrics" items={ping.metrics} appName={params.app} />
 {:catch}

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -1,6 +1,7 @@
 <script>
   import { getPingData } from "../state/api";
   import { pageTitle } from "../state/stores";
+  import { getBigQueryURL } from "../state/urls";
 
   import AppVariantSelector from "../components/AppVariantSelector.svelte";
   import HelpHoverable from "../components/HelpHoverable.svelte";
@@ -59,7 +60,9 @@
         </td>
         <td>
           <a
-            href={`/apps/${params.app}/app_ids/${selectedAppVariant.app_id}/tables/${params.ping}`}>{selectedAppVariant.table}</a>
+            href={getBigQueryURL(params.app, selectedAppVariant.app_id, params.ping)}>
+            {selectedAppVariant.table}
+          </a>
         </td>
       </tr>
     </table>

--- a/src/pages/TableDetail.svelte
+++ b/src/pages/TableDetail.svelte
@@ -47,7 +47,7 @@
     </tr>
   </table>
   <SchemaViewer
-    app={params.appId}
+    app={params.app}
     nodes={table.bq_schema}
     bind:searchText={queryString}
     on:updateURL={updateURL} />

--- a/src/pages/TableDetail.svelte
+++ b/src/pages/TableDetail.svelte
@@ -12,11 +12,11 @@
 
   const dispatch = createEventDispatcher();
 
-  const pingDataPromise = getTableData(params.app, params.table);
+  const pingDataPromise = getTableData(params.app, params.appId, params.table);
 
   const updateURL = () => dispatch("updateURL", queryString);
 
-  pageTitle.set(`${params.table} table | ${params.app}`);
+  pageTitle.set(`${params.table} table | ${params.appId}`);
 </script>
 
 <style>
@@ -25,7 +25,7 @@
 </style>
 
 {#await pingDataPromise then table}
-  <PageTitle text={`Table <code>${table.name}</code> for ${params.app}`} />
+  <PageTitle text={`Table <code>${table.name}</code> for ${table.app_id}`} />
   <table>
     <col />
     <col />
@@ -47,10 +47,10 @@
     </tr>
   </table>
   <SchemaViewer
-    app={params.app}
+    app={params.appId}
     nodes={table.bq_schema}
     bind:searchText={queryString}
     on:updateURL={updateURL} />
 {:catch}
-  <NotFound pageName={params.app} itemType="table" />
+  <NotFound pageName={params.appId} itemType="table" />
 {/await}

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -9,6 +9,10 @@ export async function getAppData(appName) {
   return fetchJSON(`/data/${appName}/index.json`);
 }
 
+export async function getAppIdData(appName, appId) {
+  return fetchJSON(`/data/${appName}/app_ids/${appId}.json`);
+}
+
 export async function getPingData(appName, pingName) {
   return fetchJSON(`/data/${appName}/pings/${pingName}.json`);
 }
@@ -17,6 +21,6 @@ export async function getMetricData(appName, metricName) {
   return fetchJSON(`/data/${appName}/metrics/${metricName}.json`);
 }
 
-export async function getTableData(appName, pingName) {
-  return fetchJSON(`/data/${appName}/tables/${pingName}.json`);
+export async function getTableData(appName, appId, pingName) {
+  return fetchJSON(`/data/${appName}/tables/${appId}/${pingName}.json`);
 }

--- a/src/state/urls.js
+++ b/src/state/urls.js
@@ -2,7 +2,7 @@ function getResourceName(name) {
   // workaround servers that incorrectly interpret url resources with a "." in
   // them as having an extension (this is common for metrics and application ids) -- the glean
   // schema doesn't allow `-`'s in metrics, so this should be ok
-  return name.replace(/\./g, "_").lower();
+  return name.replace(/\./g, "_").toLowerCase();
 }
 
 export function getItemURL(appName, itemType, itemName) {

--- a/src/state/urls.js
+++ b/src/state/urls.js
@@ -9,8 +9,10 @@ export function getItemURL(appName, itemType, itemName) {
   return `/apps/${appName}/${itemType}/${getResourceName(itemName)}`;
 }
 
-export function getMetricBigQueryURL(appName, appId, pingName, metricName) {
+export function getBigQueryURL(appName, appId, pingName, metricName) {
   return metricName
-    ? `/apps/${appName}/app_ids/${appId}/tables/${pingName}?search=${metricName}`
+    ? `/apps/${appName}/app_ids/${getResourceName(
+        appId
+      )}/tables/${pingName}?search=${metricName}`
     : `/apps/${appName}/app_ids/${getResourceName(appId)}/tables/${pingName}`;
 }

--- a/src/state/urls.js
+++ b/src/state/urls.js
@@ -1,12 +1,16 @@
-export function getItemURL(appName, itemType, itemName) {
+function getResourceName(name) {
   // workaround servers that incorrectly interpret url resources with a "." in
-  // them as having an extension (this is common for metrics) -- the glean
+  // them as having an extension (this is common for metrics and application ids) -- the glean
   // schema doesn't allow `-`'s in metrics, so this should be ok
-  return `/apps/${appName}/${itemType}/${itemName.replace(/\./g, "_")}`;
+  return name.replace(/\./g, "_");
 }
 
-export function getMetricBigQueryURL(appName, pingName, metricName) {
+export function getItemURL(appName, itemType, itemName) {
+  return `/apps/${appName}/${itemType}/${getResourceName(itemName)}`;
+}
+
+export function getMetricBigQueryURL(appName, appId, pingName, metricName) {
   return metricName
-    ? `/apps/${appName}/tables/${pingName}?search=${metricName}`
-    : `/apps/${appName}/tables/${pingName}`;
+    ? `/apps/${appName}/app_ids/${appId}/tables/${pingName}?search=${metricName}`
+    : `/apps/${appName}/app_ids/${getResourceName(appId)}/tables/${pingName}`;
 }

--- a/src/state/urls.js
+++ b/src/state/urls.js
@@ -10,9 +10,9 @@ export function getItemURL(appName, itemType, itemName) {
 }
 
 export function getBigQueryURL(appName, appId, pingName, metricName) {
-  return metricName
-    ? `/apps/${appName}/app_ids/${getResourceName(
-        appId
-      )}/tables/${pingName}?search=${metricName}`
-    : `/apps/${appName}/app_ids/${getResourceName(appId)}/tables/${pingName}`;
+  const base = `/apps/${getResourceName(appName)}/app_ids/${getResourceName(
+    appId
+  )}/tables/${pingName}`;
+
+  return base + (metricName ? `?search=${metricName}` : "");
 }

--- a/src/state/urls.js
+++ b/src/state/urls.js
@@ -2,7 +2,7 @@ function getResourceName(name) {
   // workaround servers that incorrectly interpret url resources with a "." in
   // them as having an extension (this is common for metrics and application ids) -- the glean
   // schema doesn't allow `-`'s in metrics, so this should be ok
-  return name.replace(/\./g, "_").toLowerCase();
+  return name.replace(/\./g, "_");
 }
 
 export function getItemURL(appName, itemType, itemName) {

--- a/src/state/urls.js
+++ b/src/state/urls.js
@@ -2,7 +2,7 @@ function getResourceName(name) {
   // workaround servers that incorrectly interpret url resources with a "." in
   // them as having an extension (this is common for metrics and application ids) -- the glean
   // schema doesn't allow `-`'s in metrics, so this should be ok
-  return name.replace(/\./g, "_");
+  return name.replace(/\./g, "_").lower();
 }
 
 export function getItemURL(appName, itemType, itemName) {

--- a/stories/AppVariantSelector.stories.js
+++ b/stories/AppVariantSelector.stories.js
@@ -1,0 +1,9 @@
+import AppVariantSelector from "./AppVariantSelector.svelte";
+
+export default {
+  title: "App Variant Selector",
+};
+
+export const Text = () => ({
+  Component: AppVariantSelector,
+});

--- a/stories/AppVariantSelector.stories.js
+++ b/stories/AppVariantSelector.stories.js
@@ -4,6 +4,6 @@ export default {
   title: "App Variant Selector",
 };
 
-export const Text = () => ({
+export const Default = () => ({
   Component: AppVariantSelector,
 });

--- a/stories/AppVariantSelector.svelte
+++ b/stories/AppVariantSelector.svelte
@@ -1,0 +1,6 @@
+<script>
+  import AppVariantSelector from "../src/components/AppVariantSelector.svelte";
+</script>
+
+<AppVariantSelector
+  variants={[{ app_id: 'org.mozilla.fenix', app_channel: 'nightly' }, { app_id: 'org.mozilla.fenix_release', app_channel: 'release' }]} />

--- a/stories/itemlist.stories.js
+++ b/stories/itemlist.stories.js
@@ -3,7 +3,7 @@ import ItemList from "../src/components/ItemList.svelte";
 const testData = {
   name: "Test data",
   metrics: [...Array(21).keys()].map((i) => ({
-    name: `Test metric ${i}`,
+    name: `test metric ${i}`,
     description: `This is test metric ${i}`,
     type: `metric_type`,
   })),

--- a/tests/state.urls.test.js
+++ b/tests/state.urls.test.js
@@ -1,9 +1,30 @@
-import { getItemURL } from "../src/state/urls";
+import { getItemURL, getBigQueryURL } from "../src/state/urls";
 
 describe("metric URL replacing", () => {
   it("works as expected", () => {
     expect(getItemURL("foo", "metrics", "bar.baz")).toEqual(
       "/apps/foo/metrics/bar_baz"
+    );
+  });
+});
+
+describe("getting bigquery urls", () => {
+  it("works as expected when you provide a metric name", () => {
+    expect(
+      getBigQueryURL(
+        "fenix",
+        "org.mozilla.fenix",
+        "activation",
+        "activation.activation_id"
+      )
+    ).toEqual(
+      "/apps/fenix/app_ids/org_mozilla_fenix/tables/activation?search=activation.activation_id"
+    );
+  });
+
+  it("works as expected when you don't provide a metric name", () => {
+    expect(getBigQueryURL("fenix", "org.mozilla.fenix", "activation")).toEqual(
+      "/apps/fenix/app_ids/org_mozilla_fenix/tables/activation"
     );
   });
 });


### PR DESCRIPTION
This changes the Glean Dictionary so that it displays apps of the same type (e.g. all the variants of Firefox for Android) together. One thing that's still missing: the application / description fields on the front page look horrible since we have no concept of a "canonical app description". We'll probably need to add this to probe-scraper-- looking into that right now, but putting this up for initial inspection / perusal.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
