### PR TITLE
Link back to metric and ping definitions in source control (fixes #223)

### DIFF
--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -41,7 +41,7 @@ export const METRIC_DEFINITION_SCHEMA = [
     title: "Source",
     id: "source_url",
     type: "link",
-    helpText: "Where the source definition of the metric may be found.",
+    helpText: "Where the source definition of the metric may be found (referencing the first commit in which it was introduced).",
     valueFormatter: getSourceUrlTitle,
   },
   {

--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -1,6 +1,10 @@
 import { getEmailLink } from "../formatters/emails";
 import { getExpiryInfo } from "../formatters/expiry";
-import { getBugURL, getBugLinkTitle } from "../formatters/links";
+import {
+  getBugURL,
+  getBugLinkTitle,
+  getSourceUrlTitle,
+} from "../formatters/links";
 import { getSearchfoxLink } from "../formatters/searchfox";
 
 const REQUIRED_METRIC_PARAMS_DOCS =
@@ -38,6 +42,7 @@ export const METRIC_DEFINITION_SCHEMA = [
     id: "source_url",
     type: "link",
     helpText: "Where the source definition of the metric may be found.",
+    valueFormatter: getSourceUrlTitle,
   },
   {
     title: "Searchfox",
@@ -165,6 +170,7 @@ export const PING_SCHEMA = [
     id: "source_url",
     type: "link",
     helpText: "Where the source definition of the ping may be found.",
+    valueFormatter: getSourceUrlTitle,
   },
   {
     title: "Includes Client Identifier",

--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -11,7 +11,6 @@ const REQUIRED_METRIC_PARAMS_DOCS =
   "https://mozilla.github.io/glean/book/user/metric-parameters.html#required-metric-parameters";
 const OPTIONAL_METRIC_PARAMS_DOCS =
   "https://mozilla.github.io/glean/book/user/metric-parameters.html#optional-metric-parameters";
-
 export const APPLICATION_DEFINITION_SCHEMA = [
   {
     title: "Source",
@@ -35,13 +34,13 @@ export const APPLICATION_DEFINITION_SCHEMA = [
     linkFormatter: getEmailLink,
   },
 ];
-
 export const METRIC_DEFINITION_SCHEMA = [
   {
     title: "Source",
     id: "source_url",
     type: "link",
-    helpText: "Where the source definition of the metric may be found (referencing the first commit in which it was introduced).",
+    helpText:
+      "Where the source definition of the metric may be found (referencing the first commit in which it was introduced).",
     valueFormatter: getSourceUrlTitle,
   },
   {
@@ -55,7 +54,6 @@ export const METRIC_DEFINITION_SCHEMA = [
     },
   },
 ];
-
 export const METRIC_METADATA_SCHEMA = [
   {
     title: "Lifetime",
@@ -163,7 +161,6 @@ export const METRIC_METADATA_SCHEMA = [
     valueFormatter: getExpiryInfo,
   },
 ];
-
 export const PING_SCHEMA = [
   {
     title: "Source",

--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -35,7 +35,7 @@ export const APPLICATION_DEFINITION_SCHEMA = [
 export const METRIC_DEFINITION_SCHEMA = [
   {
     title: "Source",
-    id: "repo_url",
+    id: "source_url",
     type: "link",
     helpText: "Where the source definition of the metric may be found.",
   },
@@ -160,6 +160,12 @@ export const METRIC_METADATA_SCHEMA = [
 ];
 
 export const PING_SCHEMA = [
+  {
+    title: "Source",
+    id: "source_url",
+    type: "link",
+    helpText: "Where the source definition of the ping may be found.",
+  },
   {
     title: "Includes Client Identifier",
     id: "include_client_id",

--- a/src/formatters/links.js
+++ b/src/formatters/links.js
@@ -27,3 +27,15 @@ export function getBugLinkTitle(ref) {
   // it verbatim, just remove the http/https part
   return url.replace(/^http(s?):\/\//, "");
 }
+
+export function getSourceUrlTitle(url) {
+  if (url.includes("github.com")) {
+    return url.replace(
+      /[^\d]+\/([^\d]+)\/([^\d]+)\/([^\d]+)\/([^/]+)\/(.*)/,
+      (_, orgName, repoName, _blob, _hash, path) => {
+        return `${orgName}/${repoName}/${path}`;
+      }
+    );
+  }
+  return url;
+}

--- a/tests/formatters.links.test.js
+++ b/tests/formatters.links.test.js
@@ -1,4 +1,4 @@
-import { getBugLinkTitle } from "../src/formatters/links";
+import { getBugLinkTitle, getSourceUrlTitle } from "../src/formatters/links";
 
 describe("Titles for bugzilla URLs", () => {
   it("works as expected", () => {
@@ -31,5 +31,15 @@ describe("Titles for github URLs", () => {
 describe("Titles for other issue tracker URLs", () => {
   it("works as expected", () => {
     expect(getBugLinkTitle("https://jira.com/1234")).toEqual("jira.com/1234");
+  });
+});
+
+describe("Titles for source definition", () => {
+  it("works as expected", () => {
+    expect(
+      getSourceUrlTitle(
+        "https://github.com/mozilla-mobile/fenix/blob/b01dbeeebf2b54dabbb1b60916bee4ec2c837b5f/app/metrics.yaml#L1234"
+      )
+    ).toEqual("mozilla-mobile/fenix/app/metrics.yaml#L1234");
   });
 });


### PR DESCRIPTION
After https://github.com/mozilla/probe-scraper/pull/271, we can now link metrics and pings back to their original definition in source control. 

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
