### PR TITLE
Fix repo names in Sourcegraph map

### DIFF
--- a/src/formatters/codesearch.js
+++ b/src/formatters/codesearch.js
@@ -37,9 +37,10 @@ const sourcegraphMap = {
 
   lockwise_ios: "lockwise-ios",
 
-  mach: "mach",
+  mach: "gecko-dev",
 
-  mozphab: "mozphab",
+  // https://github.com/mozilla-conduit/review
+  mozphab: "review",
 
   mozregression: "mozregression",
 };

--- a/src/formatters/codesearch.js
+++ b/src/formatters/codesearch.js
@@ -39,8 +39,6 @@ const sourcegraphMap = {
 
   mach: "gecko-dev",
 
-  // https://github.com/mozilla-conduit/review
-  mozphab: "review",
 
   mozregression: "mozregression",
 };


### PR DESCRIPTION
Something I noticed while playing around with the new Sourcegraph implementation, which looks great by the way @jcads!

Example:

Old code search for [`mach.command`](https://dictionary.protosaur.dev/apps/mach/metrics/mach_command):
https://sourcegraph.com/search?q=repo:%5Egithub%5C.com%5C/%5BMm%5Dozilla%28.*%29%5C/mach%24+mach.command|Mach.command|mach.command|mach::command&patternType=regexp

New code search: 
https://sourcegraph.com/search?q=repo:%5Egithub%5C.com%5C/%5BMm%5Dozilla%28.*%29%5C/gecko-dev%24+mach.command|Mach.command|mach.command|mach::command&patternType=regexp
 
### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
