### PR TITLE
Re-add mozphab repo to sourcegraph repos

### DIFF
--- a/src/formatters/codesearch.js
+++ b/src/formatters/codesearch.js
@@ -39,6 +39,8 @@ const sourcegraphMap = {
 
   mach: "gecko-dev",
 
+  mozphab: "review",
+
   mozregression: "mozregression",
 };
 

--- a/src/formatters/codesearch.js
+++ b/src/formatters/codesearch.js
@@ -70,7 +70,7 @@ export const getCodeSearchLink = (app, metric) => {
     ? `${snakeCase(category)}::${snakeCase(name)}`
     : snakeCase(category);
 
-  const allLanguagePatterns = `${camelCased}|${capitalizedCamelCased}|${snakedCased}|${dblColonSnakeCased}`;
+  const allLanguagePatterns = `${metric}|${camelCased}|${capitalizedCamelCased}|${snakedCased}|${dblColonSnakeCased}`;
 
   /* eslint no-else-return: "error" */
 

--- a/tests/formatters.codesearch.test.js
+++ b/tests/formatters.codesearch.test.js
@@ -3,12 +3,12 @@ import { getCodeSearchLink } from "../src/formatters/codesearch";
 describe("Searchfox links for firefox-desktop", () => {
   it("works as expected", () => {
     expect(getCodeSearchLink("firefox_desktop", "test.metric_name")).toEqual(
-      "https://searchfox.org/mozilla-central/search?q=test.metricName|Test.metricName|test.metric_name|test::metric_name&regexp=true"
+      "https://searchfox.org/mozilla-central/search?q=test.metric_name|test.metricName|Test.metricName|test.metric_name|test::metric_name&regexp=true"
     );
     expect(
       getCodeSearchLink("firefox_desktop", "test_category.test_name")
     ).toEqual(
-      "https://searchfox.org/mozilla-central/search?q=testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&regexp=true"
+      "https://searchfox.org/mozilla-central/search?q=test_category.test_name|testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&regexp=true"
     );
   });
 });
@@ -16,10 +16,10 @@ describe("Searchfox links for firefox-desktop", () => {
 describe("Searchfox links for applications in mozilla-mobile", () => {
   it("works as expected", () => {
     expect(getCodeSearchLink("fenix", "test.metric_name")).toEqual(
-      "https://searchfox.org/mozilla-mobile/search?q=test.metricName|Test.metricName|test.metric_name|test::metric_name&path=fenix&regexp=true"
+      "https://searchfox.org/mozilla-mobile/search?q=test.metric_name|test.metricName|Test.metricName|test.metric_name|test::metric_name&path=fenix&regexp=true"
     );
     expect(getCodeSearchLink("fenix", "test_category.test_name")).toEqual(
-      "https://searchfox.org/mozilla-mobile/search?q=testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&path=fenix&regexp=true"
+      "https://searchfox.org/mozilla-mobile/search?q=test_category.test_name|testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&path=fenix&regexp=true"
     );
   });
 });
@@ -27,7 +27,7 @@ describe("Searchfox links for applications in mozilla-mobile", () => {
 describe("returns Sourcegraph link if the application is not indexed on Searchfox", () => {
   it("works as expected", () => {
     expect(getCodeSearchLink("mozregression", "usage.bad_date")).toEqual(
-      "https://sourcegraph.com/search?q=repo:%5Egithub%5C.com%5C/%5BMm%5Dozilla%28.*%29%5C/mozregression%24+usage.badDate|Usage.badDate|usage.bad_date|usage::bad_date&patternType=regexp"
+      "https://sourcegraph.com/search?q=repo:%5Egithub%5C.com%5C/%5BMm%5Dozilla%28.*%29%5C/mozregression%24+usage.bad_date|usage.badDate|Usage.badDate|usage.bad_date|usage::bad_date&patternType=regexp"
     );
   });
 });


### PR DESCRIPTION
@Iinh correctly pointed out in #480 that we do have sourcegraph indexing for mozphab. So this PR re-adds it. However the search string currently fails because it winds up being something like:

https://sourcegraph.com/search?q=repo:%5Egithub%5C.com%5C/%5BMm%5Dozilla%28.*%29%5C/mozphab%24+mozphabEnvironment.distributionVersion|MozphabEnvironment.distributionVersion|mozphab_environment.distribution_version|mozphab_environment::distribution_version&patternType=regexp

for `mozphab.environment.distribution_version`

Note that this (adhoc) query works fine:

https://sourcegraph.com/search?q=repo:%5Egithub%5C.com%5C/%5BMm%5Dozilla%28.*%29%5C/review%24+mozphab.environment.distribution_version&patternType=regexp

I think the code to create the search regex wasn't designed to handle metrics with three levels of nesting like this. Not sure what the right solution is here, @badboy any ideas? Code in question is here:

https://github.com/mozilla/glean-dictionary/blob/0de7cbab440aa683275fcef01bc969927dbc9e3b/src/formatters/codesearch.js#L46

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
