### PR TITLE
Fix angle brackets (hopefully for the last time)

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -1756,7 +1756,11 @@ exports[`Storyshots Markdown Text With Angle Brackets 1`] = `
   
 
   <p>
-    markdown &lt;&gt; with angle &lt;brackets&gt;
+    markdown &lt;&gt; with angle &lt;brackets&gt; (unquoted) and more angle 
+    <code>
+      &lt;brackets&gt;
+    </code>
+     (quoted)
   </p>
   
 

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -13,20 +13,19 @@
         start ? `start="${start}"` : ""
       } class="mzp-u-list-styled">${body}</${outerEl}>`;
     },
+    html(html) {
+      return `<code>${html.replace("<", "&lt;")}</code>`;
+    },
   };
   use({ renderer });
 
   export let text;
   // if inline is set, do not wrap the markdown in a paragraph -- useful for short snippets
   export let inline = true;
-
-  // escape `<` so it doesn't get confused as an HTML tag, see:
-  // https://github.com/mozilla/glean-dictionary/pull/497
-  $: htmlText = text.replace("<", "&lt;");
 </script>
 
 {#if inline}
-  {@html parseInline(htmlText)}
+  {@html parseInline(text)}
 {:else}
-  {@html parse(htmlText)}
+  {@html parse(text)}
 {/if}

--- a/stories/markdown.stories.js
+++ b/stories/markdown.stories.js
@@ -3,7 +3,8 @@ import Markdown from "../src/components/Markdown.svelte";
 
 const mark =
   "A *text* in markdown [moz](https://mozilla.org).\n\nA list:\n\n* Lorem\n* Ipsum\n\nThis is an ordered list starting from 2:\n\n2. Foo\n3. Bar";
-const markWithBracket = "A <text> in\n\nmarkdown <> with angle <brackets>";
+const markWithBracket =
+  "A <text> in\n\nmarkdown <> with angle <brackets> (unquoted) and more angle `<brackets>` (quoted)";
 
 const inline = false;
 


### PR DESCRIPTION
PR #497 fixed some cases, but not all. Angle brackets in
code blocks have their own escaping behaviour, which doesn't
work well with the adhoc work we're doing.
    
Strictly a string like this:
    
    <provider>
    
is considered HTML in markdown. However this *probably* isn't
how we want to interpret it in the Glean Dictionary. We'll
address this by modifying the renderer when it encounters an
HTML tag, rather than doing a naive regex replace against the
whole markdown string.


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
