### PR TITLE
Fix sending google analytics page view events

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -73,17 +73,17 @@
   }
 
   page("*", parseQuery);
+  page("*", (ctx, next) => {
+    ga("set", "page", ctx.page.current);
+    ga("send", "pageview");
+    next();
+  });
   page("/", setComponent(AppList));
   page("/apps/:app/app_ids/:appId/tables/:table", setComponent(TableDetail));
   page("/apps/:app/app_ids/:appId", setComponent(AppIdDetail));
   page("/apps/:app/pings/:ping", setComponent(PingDetail));
   page("/apps/:app/metrics/:metric", setComponent(MetricDetail));
   page("/apps/:app", setComponent(AppDetail));
-  page.exit("*", (ctx, next) => {
-    ga("set", "page", ctx.page.current);
-    ga("send", "pageview");
-    next();
-  });
   page();
 
   // set up a handler to update our URL when page state changes (we do this here,

--- a/src/ga.js
+++ b/src/ga.js
@@ -5,5 +5,4 @@ export const googleAnalytics = (gaID) => {
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', gaID, 'auto');
-  ga('send', 'pageview');
 };


### PR DESCRIPTION
We should send them when we enter a page, not when we leave them.

(the initial load worked before, this is just for subsequent page
views)

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
