### PR TITLE
Bypass cache when accessing probeinfo.telemetry.mozilla.org

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 autoflake
 black
-cachecontrol
 flake8
 flake8-black
 isort


### PR DESCRIPTION
In discussion on #glean-dictionary, there's some question about what will disable cloudfront's cache. But per https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-custom-object-caching/:

> Review the Cache-Control header in the response. If the value for Cache-Control is "no-store," then the header is directing CloudFront to not cache the response. If the value for Cache-Control is "no-cache," then the header is directing CloudFront to verify with the origin before returning a cached response. These directives supersede the Maximum TTL and Default TTL CloudFront settings.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
