### PR TITLE
Remove upload-to-protosaur step from build (fixes #537)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 orbs:
   node: circleci/node@2.0.1
   python: circleci/python@0.2.1
-  gcs: t3n/gcs@0.1.3
 jobs:
   build-and-test:
     executor:
@@ -15,12 +14,6 @@ jobs:
       - run: npm run build
       - run: npm run build-storybook
       - run: npm test
-      - run: mkdir /tmp/workspace
-      - run: cp -r public /tmp/workspace
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - public/*
   python-build-and-test:
     executor: python/default
     steps:
@@ -30,54 +23,8 @@ jobs:
           name: Run lint
           command: make lint
       - run: scripts/build-glean-metadata.py
-      - run: mkdir /tmp/workspace-data
-      - run: cp -r public/data/* /tmp/workspace-data
-      - persist_to_workspace:
-          root: /tmp/workspace-data
-          paths:
-            - ./*
-  upload:
-    # this job uploads the built artifacts to the GCS bucket
-    # used to serve https://dictionary.protosaur.dev/
-    docker:
-      - image: google/cloud-sdk
-    working_directory: /tmp
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
-      - attach_workspace:
-          at: /tmp/workspace-data
-      - run: cp -r /tmp/workspace-data/* /tmp/workspace/public/data
-      - gcs/gcs-rsync:
-          bucket: glean-dictionary-dev
-          source: /tmp/workspace/public
-          options: -r -d
 workflows:
   build-and-test:
     jobs:
       - build-and-test
       - python-build-and-test
-      - upload:
-          requires:
-            - build-and-test
-            - python-build-and-test
-          filters:
-            branches:
-              only: main
-  nightly-deploy:
-    # to ensure we're displaying fresh data, do a deploy every day at 4am UTC
-    # (should be just after probe-scraper + MPS generation)
-    triggers:
-      - schedule:
-          cron: "0 4 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - build-and-test
-      - python-build-and-test
-      - upload:
-          requires:
-            - build-and-test
-            - python-build-and-test


### PR DESCRIPTION
* dictionary.telemetry.mozilla.org now deploys from netlify
* glean-dictionary-dev.netlify.app is now the 'official' staging
  server

To reduce confusion, I'm going to turn dictionary.protosaur.dev into a
set of redirects to dictionary.telemetry.mozilla.org after this lands.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
