### PR TITLE
Allow and show "app" annotations (fixes #557)

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -74,6 +74,7 @@ for app in apps:
             "url": app.app["url"],
             "notification_emails": app.app["notification_emails"],
             "app_ids": [],
+            "annotation": (annotations_index.get(app.app_name, {}).get("app")),
         }
     app_groups[app.app_name]["app_ids"].extend(
         [

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -45,6 +45,8 @@ exports[`Storyshots App Alert Text 1`] = `
       class="alert-text svelte-q7l1in"
     >
       Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.
+      
+      
     </div>
   </div>
    
@@ -100,6 +102,8 @@ exports[`Storyshots App Alert Text 1`] = `
       class="alert-text svelte-q7l1in"
     >
       Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.
+      
+      
     </div>
   </div>
    
@@ -138,6 +142,8 @@ exports[`Storyshots App Alert Text 1`] = `
       class="alert-text svelte-q7l1in"
     >
       Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old.
+      
+      
     </div>
   </div>
 </section>

--- a/src/components/AppAlert.svelte
+++ b/src/components/AppAlert.svelte
@@ -1,6 +1,7 @@
 <script>
   import { fade } from "svelte/transition";
 
+  import Markdown from "./Markdown.svelte";
   import WarningIcon from "./icons/WarningIcon.svelte";
   import ErrorIcon from "./icons/ErrorIcon.svelte";
   import SuccessIcon from "./icons/SuccessIcon.svelte";
@@ -40,5 +41,7 @@
 
 <div class="mzp-c-notification-bar mzp-t-{status} {status}" transition:fade>
   <svelte:component this={icons[status]} />
-  <div class="alert-text">{message}</div>
+  <div class="alert-text">
+    <Markdown text={message} inline={true} />
+  </div>
 </div>

--- a/src/components/Commentary.svelte
+++ b/src/components/Commentary.svelte
@@ -4,20 +4,25 @@
 
   export let itemType;
   export let item;
+
+  let annotationPath =
+    itemType === "application"
+      ? `${item.app_name}/README.md`
+      : `${item.origin}/${itemType}s/${item.name}/README.md`;
 </script>
 
 {#if item.annotation}
   <Markdown text={item.annotation.content} inline={false} />
   <p>
     <a
-      href={`https://github.com/mozilla/glean-annotations/edit/main/annotations/${item.origin}/${itemType}s/${item.name}/README.md`}>Edit</a>
+      href={`https://github.com/mozilla/glean-annotations/edit/main/annotations/${annotationPath}`}>Edit</a>
   </p>
 {:else}
   <p>
     No commentary for this
     {itemType},
     <a
-      href={`https://github.com/mozilla/glean-annotations/new/main?filename=annotations/${item.origin}/${itemType}s/${item.name}/README.md&value=${encodeURIComponent(defaultAnnotation)}`}>add
+      href={`https://github.com/mozilla/glean-annotations/new/main?filename=annotations/${annotationPath}&value=${encodeURIComponent(defaultAnnotation)}`}>add
       some</a>?
   </p>
 {/if}

--- a/src/data/defaultAnnotation.md
+++ b/src/data/defaultAnnotation.md
@@ -1,4 +1,4 @@
-This is a starter template for a metric or ping annotation. If this is your
-first time writing one of these, please see the
+This is a starter template for an application, metric or ping annotation. If
+this is your first time writing one of these, please see the
 [contributing guidelines](https://github.com/mozilla/glean-annotations/blob/main/CONTRIBUTING.md)
 in the glean-annotations repository.

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -6,6 +6,7 @@
 
   import { APPLICATION_DEFINITION_SCHEMA } from "../data/schemas";
   import AppAlert from "../components/AppAlert.svelte";
+  import Commentary from "../components/Commentary.svelte";
   import ItemList from "../components/ItemList.svelte";
   import MetadataTable from "../components/MetadataTable.svelte";
   import NotFound from "../components/NotFound.svelte";
@@ -32,9 +33,16 @@
 
 <style>
   @import "../main.scss";
+  h2 {
+    @include text-title-xs;
+  }
 </style>
 
 {#await appDataPromise then app}
+  {#if app.annotation && app.annotation.warning}
+    <AppAlert status="warning" message={app.annotation.warning} />
+  {/if}
+
   {#if app.prototype}
     <AppAlert
       status="warning"
@@ -51,6 +59,9 @@
     appName={params.app}
     item={app}
     schema={APPLICATION_DEFINITION_SCHEMA} />
+
+  <h2>Commentary</h2>
+  <Commentary item={app} itemType={'application'} />
 
   <TabGroup
     active={itemType}


### PR DESCRIPTION
This includes a new type of "warning" annotation, which we can
use to redirect people to probes.telemetry.mozilla.org for
legacy Firefox telemetry.

Depends on https://github.com/mozilla/glean-annotations/pull/25

Preview:

![image](https://user-images.githubusercontent.com/20569/116601259-4c46db80-a8f8-11eb-9ed3-1710c70603cf.png)

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
