### PR TITLE
Display metric and ping "origin" information

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -133,26 +133,24 @@ for (app_name, app_group) in app_groups.items():
             if metric.identifier not in metric_identifiers_seen:
                 metric_identifiers_seen.add(metric.identifier)
 
+                base_definition = {
+                    "name": metric.identifier,
+                    "description": metric.description,
+                    "type": metric.definition["type"],
+                    "expires": metric.definition["expires"],
+                }
+                if metric.definition["origin"] != app_name:
+                    base_definition.update({"origin": metric.definition["origin"]})
+
                 # metrics with associated pings
                 metric_pings["data"].append(
-                    {
-                        "name": metric.identifier,
-                        "description": metric.description,
-                        "pings": metric.definition["send_in_pings"],
-                        "type": metric.definition["type"],
-                        "expires": metric.definition["expires"],
-                    }
+                    dict(base_definition, pings=metric.definition["send_in_pings"])
                 )
 
-                app_data["metrics"].append(
-                    {
-                        "name": metric.identifier,
-                        "description": metric.description,
-                        "type": metric.definition["type"],
-                        "expires": metric.definition["expires"],
-                    }
-                )
+                # the summary of metrics
+                app_data["metrics"].append(base_definition)
 
+                # the full definition
                 app_metrics[metric.identifier] = dict(
                     metric.definition,
                     name=metric.identifier,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,6 @@
 <script>
-  import { mapValues, pickBy } from "lodash";
   import page from "page";
-  import { stringify, parse as queryStringParse } from "query-string";
+  import { parse as queryStringParse } from "query-string";
   import { afterUpdate } from "svelte";
 
   // Pages
@@ -18,7 +17,7 @@
   import GlobalStyles from "./GlobalStyles.svelte";
 
   // Stores
-  import { pageState, pageTitle } from "./state/stores";
+  import { pageState, pageTitle, updateURLState } from "./state/stores";
 
   let component;
   let params = {};
@@ -90,17 +89,7 @@
   // instead of the store because we want to wait until we've initialized any
   // initial state before doing this)
   $: {
-    // create a simplified copy of the state so that our URLs can be shorter:
-    // don't incorporate falsely values and convert booleans to integers
-    const simplifiedState = mapValues(
-      pickBy($pageState, (v) => (typeof v !== "string" && v) || v.length > 0),
-      (v) => (typeof v === "boolean" ? +v : v)
-    );
-    // convert the state into a query string like "a=b&c=d" and attach it
-    // to the URL
-    const query = stringify(simplifiedState);
-    const path = `${window.location.pathname}${query ? `?${query}` : ""}`;
-    window.history.replaceState(null, undefined, path);
+    $pageState, updateURLState(false); // eslint-disable-line
   }
 
   // Set page title

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -497,13 +497,13 @@ exports[`Storyshots ItemList Default 1`] = `
   class="storybook-snapshot-container"
 >
   <span
-    class="expire-checkbox svelte-1s1bzuy"
+    class="expire-checkbox svelte-56ztuj"
   >
     <label
-      class="svelte-1s1bzuy"
+      class="svelte-56ztuj"
     >
       <input
-        class="svelte-1s1bzuy"
+        class="svelte-56ztuj"
         type="checkbox"
       />
       
@@ -511,10 +511,10 @@ exports[`Storyshots ItemList Default 1`] = `
     </label>
      
     <label
-      class="svelte-1s1bzuy"
+      class="svelte-56ztuj"
     >
       <input
-        class="svelte-1s1bzuy"
+        class="svelte-56ztuj"
         type="checkbox"
       />
       
@@ -534,34 +534,34 @@ exports[`Storyshots ItemList Default 1`] = `
   </div>
    
   <div
-    class="item-browser svelte-1s1bzuy"
+    class="item-browser svelte-56ztuj"
   >
     <table
-      class="mzp-u-data-table svelte-1s1bzuy"
+      class="mzp-u-data-table svelte-56ztuj"
     >
       <col
-        class="svelte-1s1bzuy"
+        class="svelte-56ztuj"
         width="35%"
       />
        
       <col
-        class="svelte-1s1bzuy"
+        class="svelte-56ztuj"
         width="20%"
       />
        
       <col
-        class="svelte-1s1bzuy"
+        class="svelte-56ztuj"
         width="45%"
       />
        
       <thead
-        class="svelte-1s1bzuy"
+        class="svelte-56ztuj"
       >
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <th
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             scope="col"
             style="text-align: center;"
           >
@@ -569,7 +569,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             scope="col"
             style="text-align: center;"
           >
@@ -577,7 +577,7 @@ exports[`Storyshots ItemList Default 1`] = `
           </th>
            
           <th
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             scope="col"
             style="text-align: center;"
           >
@@ -587,37 +587,38 @@ exports[`Storyshots ItemList Default 1`] = `
       </thead>
        
       <tbody
-        class="svelte-1s1bzuy"
+        class="svelte-56ztuj"
       >
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 0"
               >
                 test metric 0
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -625,10 +626,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 0"
             >
               This is test metric 0
@@ -639,34 +640,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 1"
               >
                 test metric 1
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -674,10 +676,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 1"
             >
               This is test metric 1
@@ -688,34 +690,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 2"
               >
                 test metric 2
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -723,10 +726,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 2"
             >
               This is test metric 2
@@ -737,34 +740,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 3"
               >
                 test metric 3
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -772,10 +776,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 3"
             >
               This is test metric 3
@@ -786,34 +790,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 4"
               >
                 test metric 4
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -821,10 +826,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 4"
             >
               This is test metric 4
@@ -835,34 +840,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 5"
               >
                 test metric 5
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -870,10 +876,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 5"
             >
               This is test metric 5
@@ -884,34 +890,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 6"
               >
                 test metric 6
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -919,10 +926,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 6"
             >
               This is test metric 6
@@ -933,34 +940,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 7"
               >
                 test metric 7
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -968,10 +976,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 7"
             >
               This is test metric 7
@@ -982,34 +990,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 8"
               >
                 test metric 8
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1017,10 +1026,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 8"
             >
               This is test metric 8
@@ -1031,34 +1040,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 9"
               >
                 test metric 9
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1066,10 +1076,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 9"
             >
               This is test metric 9
@@ -1080,34 +1090,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 10"
               >
                 test metric 10
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1115,10 +1126,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 10"
             >
               This is test metric 10
@@ -1129,34 +1140,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 11"
               >
                 test metric 11
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1164,10 +1176,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 11"
             >
               This is test metric 11
@@ -1178,34 +1190,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 12"
               >
                 test metric 12
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1213,10 +1226,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 12"
             >
               This is test metric 12
@@ -1227,34 +1240,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 13"
               >
                 test metric 13
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1262,10 +1276,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 13"
             >
               This is test metric 13
@@ -1276,34 +1290,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 14"
               >
                 test metric 14
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1311,10 +1326,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 14"
             >
               This is test metric 14
@@ -1325,34 +1340,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 15"
               >
                 test metric 15
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1360,10 +1376,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 15"
             >
               This is test metric 15
@@ -1374,34 +1390,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 16"
               >
                 test metric 16
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1409,10 +1426,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 16"
             >
               This is test metric 16
@@ -1423,34 +1440,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 17"
               >
                 test metric 17
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1458,10 +1476,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 17"
             >
               This is test metric 17
@@ -1472,34 +1490,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 18"
               >
                 test metric 18
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1507,10 +1526,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 18"
             >
               This is test metric 18
@@ -1521,34 +1540,35 @@ exports[`Storyshots ItemList Default 1`] = `
            
         </tr>
         <tr
-          class="svelte-1s1bzuy"
+          class="svelte-56ztuj"
         >
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <a
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
                 href="/apps/app-name/metrics/test metric 19"
               >
                 test metric 19
               </a>
                
                
+               
             </div>
           </td>
            
           <td
-            class="svelte-1s1bzuy"
+            class="svelte-56ztuj"
             style="text-align: center;"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
             >
               <code
-                class="svelte-1s1bzuy"
+                class="svelte-56ztuj"
               >
                 metric_type
               </code>
@@ -1556,10 +1576,10 @@ exports[`Storyshots ItemList Default 1`] = `
           </td>
            
           <td
-            class="description svelte-1s1bzuy"
+            class="description svelte-56ztuj"
           >
             <div
-              class="item-property svelte-1s1bzuy"
+              class="item-property svelte-56ztuj"
               title="This is test metric 19"
             >
               This is test metric 19
@@ -2028,7 +2048,7 @@ exports[`Storyshots Pill Deprecated 1`] = `
   class="storybook-snapshot-container"
 >
   <div
-    class="pill svelte-zw85gu"
+    class="pill  svelte-6ag9kw"
     style="background-color: rgb(74, 85, 104);"
   >
     Deprecated

--- a/src/components/FilterInput.svelte
+++ b/src/components/FilterInput.svelte
@@ -1,9 +1,6 @@
 <script>
-  import { getContext } from "svelte";
-
+  export let value = "";
   export let placeHolder;
-
-  const searchText = getContext("searchText");
 </script>
 
 <style>
@@ -19,10 +16,4 @@
   }
 </style>
 
-<div>
-  <input
-    {placeHolder}
-    type="search"
-    id="filter-input"
-    bind:value={$searchText} />
-</div>
+<div><input {placeHolder} type="search" id="filter-input" bind:value /></div>

--- a/src/components/FilterInput.svelte
+++ b/src/components/FilterInput.svelte
@@ -1,5 +1,6 @@
 <script>
-  export let value = "";
+  import { pageState } from "../state/stores";
+
   export let placeHolder;
 </script>
 
@@ -16,4 +17,10 @@
   }
 </style>
 
-<div><input {placeHolder} type="search" id="filter-input" bind:value /></div>
+<div>
+  <input
+    {placeHolder}
+    type="search"
+    id="filter-input"
+    bind:value={$pageState.search} />
+</div>

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { getContext, setContext } from "svelte";
+  import { setContext } from "svelte";
   import { writable } from "svelte/store";
   import { chunk } from "lodash";
 
@@ -11,6 +11,7 @@
   import Pill from "./Pill.svelte";
 
   import { isExpired } from "../state/metrics";
+  import { pageState, updateURLState } from "../state/stores";
 
   let DEFAULT_ITEMS_PER_PAGE = 20;
 
@@ -27,37 +28,42 @@
   let currentPage = writable(1);
   setContext("currentPage", currentPage);
 
-  const searchText = getContext("searchText");
-  const goToPage = (page, perPage = DEFAULT_ITEMS_PER_PAGE) => {
+  // re-filter items when showExpired or search text changes
+  $: {
+    const search = $pageState.search || "";
+    // don't use $currentPage, because we don't want to call this reactively
+    // when paginating
+    currentPage.set(1);
+
+    const originMatch = (item) =>
+      item.origin && item.origin.includes(search.toLowerCase());
+
+    // filter on match either on name or on origin
+    filteredItems = items.filter(
+      (item) => item.name.includes(search) || originMatch(item)
+    );
+
+    // also filter out expired items (if we're not showing expired)
+    filteredItems = $pageState.showExpired
+      ? filteredItems
+      : filteredItems.filter((item) => !isExpired(item.expires));
+  }
+
+  // update pagination when either pagination changes or filtered list changes
+  // (above)
+  $: {
+    const perPage = paginated ? DEFAULT_ITEMS_PER_PAGE : filteredItems.length;
     pagedItems =
       filteredItems.length > 0
-        ? chunk([...filteredItems], perPage)[page - 1]
+        ? chunk([...filteredItems], perPage)[$currentPage - 1]
         : [];
+  }
+
+  const originClicked = (origin) => {
+    $pageState = { ...$pageState, search: origin };
+    // when the user clicks on an origin (library name), we want to persist a new state
+    updateURLState(true);
   };
-
-  const showExpired = getContext("showExpired");
-
-  $: {
-    if (paginated) {
-      goToPage($currentPage);
-    } else {
-      goToPage(1, filteredItems.length);
-    }
-  }
-
-  // re-filter items when showExpired or $searchText changes
-  $: {
-    const shownItems = $showExpired
-      ? items
-      : items.filter((item) => !isExpired(item.expires));
-    filteredItems = shownItems.filter((item) =>
-      item.name.includes($searchText)
-    );
-    // show the first page of result
-    currentPage.set(1);
-    // even if currentPage is already 1, we need to manually call goToPage() to get the first page
-    goToPage(1);
-  }
 </script>
 
 <style>
@@ -68,7 +74,7 @@
   }
 
   .item-property {
-    height: 40px;
+    height: 50px;
     overflow-y: auto;
     margin: -0.25rem;
   }
@@ -116,7 +122,7 @@
   {#if itemType === 'metrics'}
     <span class="expire-checkbox">
       <label>
-        <input type="checkbox" bind:checked={$showExpired} />
+        <input type="checkbox" bind:checked={$pageState.showExpired} />
         Show expired metrics
       </label>
       <label>
@@ -126,7 +132,9 @@
     </span>
   {/if}
   {#if showFilter}
-    <FilterInput placeHolder="Search {itemType}" />
+    <FilterInput
+      placeHolder="Search {itemType}"
+      bind:value={$pageState.search} />
   {/if}
   <div class="item-browser">
     <table class="mzp-u-data-table">
@@ -151,6 +159,13 @@
               <div class="item-property">
                 <a
                   href={getItemURL(appName, itemType, item.name)}>{item.name}</a>
+                {#if item.origin && item.origin !== appName}
+                  <Pill
+                    message={item.origin}
+                    bgColor="#4a5568"
+                    clickable
+                    on:click={originClicked(item.origin)} />
+                {/if}
                 {#if isExpired(item.expires)}
                   <Pill message="Expired" bgColor="#4a5568" />
                 {/if}

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -132,9 +132,7 @@
     </span>
   {/if}
   {#if showFilter}
-    <FilterInput
-      placeHolder="Search {itemType}"
-      bind:value={$pageState.search} />
+    <FilterInput placeHolder="Search {itemType}" />
   {/if}
   <div class="item-browser">
     <table class="mzp-u-data-table">

--- a/src/components/Pill.svelte
+++ b/src/components/Pill.svelte
@@ -1,6 +1,7 @@
 <script>
   export let message = "";
   export let bgColor;
+  export let clickable = false;
 </script>
 
 <style>
@@ -12,7 +13,17 @@
     padding: 0 $spacing-sm 0 $spacing-sm;
     color: $color-light-gray-05;
     font-weight: bold;
+    margin-right: 2px;
+  }
+
+  .clickable {
+    cursor: pointer;
   }
 </style>
 
-<div style="background-color: {bgColor}" class="pill">{message}</div>
+<div
+  style="background-color: {bgColor}"
+  class="pill {clickable ? 'clickable' : ''}"
+  on:click>
+  {message}
+</div>

--- a/src/components/SchemaViewer.svelte
+++ b/src/components/SchemaViewer.svelte
@@ -1,17 +1,18 @@
 <script>
-  import { getContext } from "svelte";
   import SchemaNode from "./SchemaNode.svelte";
   import FilterInput from "./FilterInput.svelte";
   import PageTitle from "./PageTitle.svelte";
+
+  import { pageState } from "../state/stores";
 
   export let app;
   export let nodes = [];
 
   let nodesWithVisibility = [];
 
-  const searchText = getContext("searchText");
   $: {
-    const filterTerms = $searchText
+    const { search } = $pageState;
+    const filterTerms = search
       .trim()
       .split(" ")
       .filter((t) => t.length > 0);
@@ -64,7 +65,7 @@
 <div class="schema-viewer">
   <PageTitle text={'Schema'} />
 
-  <FilterInput />
+  <FilterInput bind:value={$pageState.search} />
   <div class="schema-browser">
     <p>
       {#each nodesWithVisibility as node}

--- a/src/components/SchemaViewer.svelte
+++ b/src/components/SchemaViewer.svelte
@@ -65,7 +65,7 @@
 <div class="schema-viewer">
   <PageTitle text={'Schema'} />
 
-  <FilterInput bind:value={$pageState.search} />
+  <FilterInput />
   <div class="schema-browser">
     <p>
       {#each nodesWithVisibility as node}

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -1,7 +1,4 @@
 <script>
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
-
   import { getAppData } from "../state/api";
 
   import { APPLICATION_DEFINITION_SCHEMA } from "../data/schemas";
@@ -19,14 +16,12 @@
 
   const appDataPromise = getAppData(params.app);
 
-  let itemType = $pageState.itemType || "metrics";
-  const searchText = writable($pageState.search || "");
-  setContext("searchText", searchText);
-  const showExpired = writable($pageState.showExpired || true);
-  setContext("showExpired", showExpired);
-  $: {
-    pageState.set({ itemType, search: $searchText, showExpired: $showExpired });
-  }
+  $pageState = {
+    itemType: "metrics",
+    search: "",
+    showExpired: false,
+    ...$pageState,
+  };
 
   pageTitle.set(params.app);
 </script>
@@ -64,10 +59,9 @@
   <Commentary item={app} itemType={'application'} />
 
   <TabGroup
-    active={itemType}
+    active={$pageState.itemType}
     on:tabChanged={({ detail }) => {
-      itemType = detail.active;
-      searchText.set('');
+      pageState.set({ ...$pageState, itemType: detail.active, search: '' });
     }}>
     <Tab key="metrics">Metrics</Tab>
     <Tab key="pings">Pings</Tab>

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -19,7 +19,7 @@
   $pageState = {
     itemType: "metrics",
     search: "",
-    showExpired: false,
+    showExpired: true,
     ...$pageState,
   };
 

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -1,7 +1,6 @@
 <script>
   import { includes } from "lodash";
-  import { onMount, setContext } from "svelte";
-  import { writable } from "svelte/store";
+  import { onMount } from "svelte";
 
   import { fetchJSON } from "../state/api";
 
@@ -11,6 +10,11 @@
   import { pageState, pageTitle } from "../state/stores";
 
   const URL = "data/apps.json";
+
+  $pageState = {
+    search: "",
+    ...$pageState,
+  };
 
   let apps;
   let filteredApps;
@@ -25,22 +29,13 @@
     filteredApps = apps;
   });
 
-  const searchText = writable($pageState.search || "");
-  setContext("searchText", searchText);
-  $: {
-    // update the search text if the store changes on us
-    // (e.g. the user clicks on "glean dictionary" when
-    // they have a filter set, resetting the filter)
-    searchText.set($pageState.search || "");
-  }
   $: {
     // update page state when user filters something
-    pageState.set({ search: $searchText });
     if (apps) {
       filteredApps = apps.filter((appItem) =>
         appItem.canonical_app_name
           .toLowerCase()
-          .includes($searchText.toLowerCase())
+          .includes($pageState.search.toLowerCase())
       );
     }
   }
@@ -167,7 +162,9 @@
 
 {#if apps}
   <div class="app-filter">
-    <FilterInput placeHolder="Search for an application" />
+    <FilterInput
+      placeHolder="Search for an application"
+      bind:value={$pageState.search} />
     <span id="deprecation-checkbox">
       <label>
         <input type="checkbox" bind:checked={showDeprecated} />

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -162,9 +162,7 @@
 
 {#if apps}
   <div class="app-filter">
-    <FilterInput
-      placeHolder="Search for an application"
-      bind:value={$pageState.search} />
+    <FilterInput placeHolder="Search for an application" />
     <span id="deprecation-checkbox">
       <label>
         <input type="checkbox" bind:checked={showDeprecated} />

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -96,6 +96,12 @@
       message="This metric has expired: it may not be present in the source code, new data will not be ingested into BigQuery, and it will not appear in dashboards." />
   {/if}
 
+  {#if metric.origin !== params.app}
+    <AppAlert
+      status="warning"
+      message={`This metric is defined by a library used by the application (__${metric.origin}__), rather than the application itself. For more details, see the definition.`} />
+  {/if}
+
   <PageTitle text={metric.name} />
 
   <Markdown text={metric.description} inline={false} />

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -26,7 +26,7 @@
 
   $pageState = {
     search: "",
-    showExpired: false,
+    showExpired: true,
     ...$pageState,
   };
   pageTitle.set(`${params.ping} | ${params.app}`);

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -1,11 +1,9 @@
 <script>
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
-
   import { getPingData } from "../state/api";
   import { pageState, pageTitle } from "../state/stores";
   import { getBigQueryURL, getLookerURL } from "../state/urls";
 
+  import AppAlert from "../components/AppAlert.svelte";
   import AppVariantSelector from "../components/AppVariantSelector.svelte";
   import Commentary from "../components/Commentary.svelte";
   import HelpHoverable from "../components/HelpHoverable.svelte";
@@ -26,14 +24,11 @@
     }
   );
 
-  const searchText = writable($pageState.search || "");
-  setContext("searchText", searchText);
-  const showExpired = writable($pageState.showExpired || false);
-  setContext("showExpired", showExpired);
-  $: {
-    pageState.set({ search: $searchText, showExpired: $showExpired });
-  }
-
+  $pageState = {
+    search: "",
+    showExpired: false,
+    ...$pageState,
+  };
   pageTitle.set(`${params.ping} | ${params.app}`);
 </script>
 
@@ -47,6 +42,12 @@
 </style>
 
 {#await pingDataPromise then ping}
+  {#if ping.origin && ping.origin !== params.app}
+    <AppAlert
+      status="warning"
+      message={`This ping is defined by a library used by the application (__${ping.origin}__), rather than the application itself. For more details, see the definition.`} />
+  {/if}
+
   <PageTitle text={ping.name} />
   <p>
     <Markdown text={ping.description} />

--- a/src/pages/TableDetail.svelte
+++ b/src/pages/TableDetail.svelte
@@ -1,7 +1,4 @@
 <script>
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
-
   import SchemaViewer from "../components/SchemaViewer.svelte";
   import { getTableData } from "../state/api";
   import { pageState, pageTitle } from "../state/stores";
@@ -13,12 +10,10 @@
 
   const pingDataPromise = getTableData(params.app, params.appId, params.table);
 
-  const searchText = writable($pageState.search || "");
-  setContext("searchText", searchText);
-  $: {
-    pageState.set({ search: $searchText });
-  }
-
+  $pageState = {
+    search: "",
+    ...$pageState,
+  };
   pageTitle.set(`${params.table} table | ${params.appId}`);
 </script>
 

--- a/src/state/stores.js
+++ b/src/state/stores.js
@@ -1,4 +1,26 @@
-import { writable } from "svelte/store";
+import { mapValues, pickBy } from "lodash";
+import { stringify } from "query-string";
+import { get, writable } from "svelte/store";
 
 export const pageTitle = writable("");
 export const pageState = writable({});
+
+// synchronizes url state with page state
+export const updateURLState = (push = false) => {
+  const simplifiedState = mapValues(
+    pickBy(get(pageState), (v) => (typeof v !== "string" && v) || v.length > 0),
+    (v) => (typeof v === "boolean" ? +v : v)
+  );
+  // convert the state into a query string like "a=b&c=d" and attach it
+  // to the URL
+  const query = stringify(simplifiedState);
+  const path = `${window.location.pathname}${query ? `?${query}` : ""}`;
+
+  // in response to some actions, we want to explicitly add a url to the
+  // page history
+  if (push) {
+    window.history.pushState(null, undefined, path);
+  } else {
+    window.history.replaceState(null, undefined, path);
+  }
+};

--- a/stories/FilterableList.svelte
+++ b/stories/FilterableList.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { setContext } from "svelte";
   import { writable } from "svelte/store";
 
   import FilterInput from "../src/components/FilterInput.svelte";
@@ -8,7 +7,6 @@
   let filteredItems = listItems;
 
   let searchText = writable("");
-  setContext("searchText", searchText);
 
   $: {
     filteredItems = listItems.filter((item) => item.includes($searchText));
@@ -16,7 +14,7 @@
 </script>
 
 <div class="container">
-  <FilterInput />
+  <FilterInput bind:value={$searchText} />
   <ul>
     {#each filteredItems as item}
       <li>{item}</li>

--- a/stories/FilterableList.svelte
+++ b/stories/FilterableList.svelte
@@ -5,8 +5,11 @@
 
   export let listItems;
 
-  let filteredItems = listItems;
+  $pageState = {
+    search: "",
+  };
 
+  let filteredItems = listItems;
   $: {
     filteredItems = listItems.filter((item) =>
       item.includes($pageState.search)

--- a/stories/FilterableList.svelte
+++ b/stories/FilterableList.svelte
@@ -1,20 +1,21 @@
 <script>
-  import { writable } from "svelte/store";
+  import { pageState } from "../src/state/stores";
 
   import FilterInput from "../src/components/FilterInput.svelte";
 
   export let listItems;
+
   let filteredItems = listItems;
 
-  let searchText = writable("");
-
   $: {
-    filteredItems = listItems.filter((item) => item.includes($searchText));
+    filteredItems = listItems.filter((item) =>
+      item.includes($pageState.search)
+    );
   }
 </script>
 
 <div class="container">
-  <FilterInput bind:value={$searchText} />
+  <FilterInput />
   <ul>
     {#each filteredItems as item}
       <li>{item}</li>

--- a/stories/ItemList.svelte
+++ b/stories/ItemList.svelte
@@ -1,15 +1,9 @@
 <script>
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
-
   import ItemList from "../src/components/ItemList.svelte";
 
   export let items;
   export let itemType;
   export let appName;
-
-  let searchText = writable("");
-  setContext("searchText", searchText);
 </script>
 
 <ItemList {items} {itemType} {appName} />

--- a/stories/SchemaViewer.svelte
+++ b/stories/SchemaViewer.svelte
@@ -1,13 +1,13 @@
 <script>
-  import { setContext } from "svelte";
-  import { writable } from "svelte/store";
+  import { pageState } from "../src/state/stores";
 
   import SchemaViewer from "../src/components/SchemaViewer.svelte";
 
   export let app;
   export let nodes;
-  export let searchText;
-  setContext("searchText", writable(searchText));
+  export let searchText = "";
+
+  pageState.set({ search: searchText, pageState });
 </script>
 
 <SchemaViewer {app} {nodes} />

--- a/stories/schemaviewer.stories.js
+++ b/stories/schemaviewer.stories.js
@@ -47,7 +47,6 @@ export const Basic = () => {
     props: {
       app: "fenix",
       nodes,
-      searchText: "",
     },
   };
 };


### PR DESCRIPTION
I.e. make it more clear when a metric or ping comes from a library.
We do this in two ways:

1. Add a small pill next to the item in the item list (if it's not
from the application in question)
2. Add a warning banner to the metric or ping page if it comes from
a library.

This is a variation of #511, focusing on a non-controversial piece of metadata that we can merge right now. I still intend to finish that feature, building on top of this PR.

Screenshots:

![image](https://user-images.githubusercontent.com/20569/117843555-e9850680-b24c-11eb-9d54-7a0da38bad58.png)

![image](https://user-images.githubusercontent.com/20569/117843431-cd816500-b24c-11eb-8841-52897e3d9db7.png)

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
