### PR TITLE
Handle `glean_internal_info` metrics correctly

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -172,8 +172,8 @@ for (app_name, app_group) in app_groups.items():
             metric_type = metric.definition["type"]
             metric_name_snakecase = stringcase.snakecase(metric.identifier)
             metric_table_name = (
-                f"client_info.{metric_name_snakecase}"
-                if metric.is_client_info
+                f"{metric.bq_prefix}.{metric_name_snakecase}"
+                if metric.bq_prefix
                 else f"metrics.{metric_type}.{metric_name_snakecase}"
             )
             bigquery_names = dict(

--- a/scripts/glean.py
+++ b/scripts/glean.py
@@ -46,7 +46,7 @@ class GleanMetric(GleanObject):
     Represents an individual Glean metric, as defined by probe scraper
     """
 
-    ALL_PINGS_KEYWORDS = ("all-pings", "all_pings", "glean_client_info")
+    ALL_PINGS_KEYWORDS = ("all-pings", "all_pings", "glean_client_info", "glean_internal_info")
 
     def __init__(self, identifier: str, definition: dict, *, ping_names: List[str] = None):
         self.identifier = identifier
@@ -54,7 +54,11 @@ class GleanMetric(GleanObject):
         self._set_definition(definition)
         self._set_description(self.definition)
 
-        self.is_client_info = "glean_client_info" in self.definition["send_in_pings"]
+        self.bq_prefix = None
+        if "glean_client_info" in self.definition["send_in_pings"]:
+            self.bq_prefix = "client_info"
+        elif "glean_internal_info" in self.definition["send_in_pings"]:
+            self.bq_prefix = "ping_info"
         if ping_names is not None:
             self._update_all_pings(ping_names)
 


### PR DESCRIPTION
These are similar to other types of glean-core metrics which should
appear in all pings.
    
For example, `seq` (https://dictionary.telemetry.mozilla.org/apps/fenix/metrics/seq)
should appear in all pings.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
