### PR TITLE
Process deprecated status for applications

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -76,6 +76,7 @@ for app in apps:
             "app_name": app.app_name,
             "app_description": app.app["app_description"],
             "canonical_app_name": app.app["canonical_app_name"],
+            "deprecated": app.app.get("deprecated", False),
             "url": app.app["url"],
             "notification_emails": app.app["notification_emails"],
             "app_ids": [],


### PR DESCRIPTION
This got accidentally broken in the migration to app groups, just
noticed now due to the addition of `rally_debug`.
