### PR TITLE
Use markdown for rendering app details

### DIFF
--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -5,6 +5,7 @@
   import AppAlert from "../components/AppAlert.svelte";
   import Commentary from "../components/Commentary.svelte";
   import ItemList from "../components/ItemList.svelte";
+  import Markdown from "../components/Markdown.svelte";
   import MetadataTable from "../components/MetadataTable.svelte";
   import NotFound from "../components/NotFound.svelte";
   import Pill from "../components/Pill.svelte";
@@ -48,7 +49,8 @@
   {#if app.deprecated}
     <Pill message="Deprecated" bgColor="#4a5568" />
   {/if}
-  <p>{app.app_description}</p>
+
+  <Markdown text={app.app_description} inline={false} />
 
   <MetadataTable
     appName={params.app}

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -5,6 +5,7 @@
   import { fetchJSON } from "../state/api";
 
   import FilterInput from "../components/FilterInput.svelte";
+  import Markdown from "../components/Markdown.svelte";
   import Pill from "../components/Pill.svelte";
 
   import { pageState, pageTitle } from "../state/stores";
@@ -211,7 +212,7 @@
                 <Pill message="Deprecated" bgColor="#4a5568" />
               {/if}
               <p class="mzp-c-card-meta" id="card-description">
-                {app.app_description}
+                <Markdown text={app.app_description} />
               </p>
             </div>
           </a>


### PR DESCRIPTION
Rally uses markdown for showing a link, which we're not currently
processing.
