### PR TITLE
Get Looker explore links from published namespaces

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ flake8-black
 isort
 requests
 stringcase
+PyYAML

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -12,7 +12,7 @@ import yaml
 
 OUTPUT_DIRECTORY = os.path.join("public", "data")
 ANNOTATIONS_URL = "https://mozilla.github.io/glean-annotations/api.json"
-NAMESPACES_URL = "https://lookml-generator-dev.netlify.app/namespaces.yaml"
+NAMESPACES_URL = "https://raw.githubusercontent.com/mozilla/looker-hub/main/namespaces.yaml"
 
 
 def _serialize_sets(obj):

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -1,7 +1,7 @@
 <script>
   import { getPingData } from "../state/api";
   import { pageState, pageTitle } from "../state/stores";
-  import { getBigQueryURL, getLookerURL } from "../state/urls";
+  import { getBigQueryURL, getLookerExploreURL } from "../state/urls";
 
   import AppAlert from "../components/AppAlert.svelte";
   import AppVariantSelector from "../components/AppVariantSelector.svelte";
@@ -82,14 +82,18 @@
           </a>
         </td>
       </tr>
-      {#if getLookerURL(params.app, params.ping)}
+      {#if ping.looker_explore}
         <tr>
           <td>
             Looker
             <HelpHoverable content={'Explore this ping in Looker.'} />
           </td>
           <td>
-            <a href={getLookerURL(params.app, params.ping)}> {params.ping} </a>
+            <a
+              href={getLookerExploreURL(params.app, params.ping.replace(/-/g, '_'))}>
+              {params.ping}
+            </a>
+            (all variants)
           </td>
         </tr>
       {/if}

--- a/src/state/urls.js
+++ b/src/state/urls.js
@@ -17,16 +17,6 @@ export function getBigQueryURL(appName, appId, pingName, metricName) {
   return base + (metricName ? `?search=${metricName}` : "");
 }
 
-export function getLookerURL(appName, pingName) {
-  // this is currently only supported for a hardcoded set of app ids and is a bit of a
-  // hack (we should ideally be doing this somewhere in our upstream ETL)
-
-  if (appName === "fenix" || appName === "burnham") {
-    return `https://mozilla.cloud.looker.com/explore/${appName}/${pingName.replace(
-      /-/g,
-      "_"
-    )}`;
-  }
-
-  return undefined;
+export function getLookerExploreURL(appName, exploreName) {
+  return `https://mozilla.cloud.looker.com/explore/${appName}/${exploreName}`;
 }


### PR DESCRIPTION
This lets us get a list of valid ping<->explore links from the
source of truth, instead of having to hardcode it in the Glean
Dictionary.

We probably shouldn't land this until the last part of https://bugzilla.mozilla.org/show_bug.cgi?id=1707727 is fixed (depends on SRE to set something up) -- as things stand, we might link to invalid explores.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
