### PR TITLE
persist pagination state in url (#528)

### DIFF
--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { getContext } from "svelte";
+  import { pageState } from "../state/stores";
 
   import BackButton from "./icons/BackButton.svelte";
   import ForwardButton from "./icons/ForwardButton.svelte";
@@ -9,7 +9,7 @@
   let from;
   let to;
   let lastPage;
-  let currentPage = getContext("currentPage");
+  let currentPage = 1;
 
   const truncatedPagination = (current, last) => {
     // Source: https://gist.github.com/kottenator/9d936eb3e4e3c3e02598#gistcomment-3413141
@@ -37,25 +37,30 @@
 
   function changePage(page) {
     if (page !== currentPage) {
-      currentPage.set(page);
+      currentPage = page;
+      $pageState.page = page;
     }
   }
 
   $: {
     lastPage = Math.ceil(totalItems / itemsPerPage);
-    from = 1 + itemsPerPage * ($currentPage - 1);
-    if ($currentPage * itemsPerPage > totalItems) {
+    from = 1 + itemsPerPage * (currentPage - 1);
+    if (currentPage * itemsPerPage > totalItems) {
       to = totalItems;
     } else {
-      to = $currentPage * itemsPerPage;
+      to = currentPage * itemsPerPage;
     }
+  }
+
+  $: {
+    currentPage = Number($pageState.page || 1);
   }
 </script>
 
 <div class="pagination-position">
   <p>
     Page
-    <code>{$currentPage}</code>
+    <code>{currentPage}</code>
     of
     <code>{lastPage}</code>
     (<code>{from}</code>
@@ -71,17 +76,17 @@
   <div class="pagination-bar">
     <div
       on:click|preventDefault={() =>
-        changePage($currentPage !== 1 ? $currentPage - 1 : 1)}
-      class="pagination-button {$currentPage === 1 ? 'current-page' : ''}"
+        changePage(currentPage !== 1 ? currentPage - 1 : 1)}
+      class="pagination-button {currentPage === 1 ? 'current-page' : ''}"
     >
       <BackButton />
     </div>
     <div class="pages">
-      {#each truncatedPagination($currentPage, lastPage) as page}
+      {#each truncatedPagination(currentPage, lastPage) as page}
         <div
           on:click|preventDefault={() =>
-            changePage(Number.isInteger(page) ? page : $currentPage)}
-          class="page {page === $currentPage ? 'current-page' : ''}"
+            changePage(Number.isInteger(page) ? page : currentPage)}
+          class="page {page === currentPage ? 'current-page' : ''}"
         >
           {page}
         </div>
@@ -89,10 +94,8 @@
     </div>
     <div
       on:click|preventDefault={() =>
-        changePage($currentPage !== lastPage ? $currentPage + 1 : lastPage)}
-      class="pagination-button {$currentPage === lastPage
-        ? 'current-page'
-        : ''}"
+        changePage(currentPage !== lastPage ? currentPage + 1 : lastPage)}
+      class="pagination-button {currentPage === lastPage ? 'current-page' : ''}"
     >
       <ForwardButton />
     </div>

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -19,6 +19,7 @@
 
   $pageState = {
     itemType: "metrics",
+    page: 1,
     search: "",
     showExpired: true,
     ...$pageState,
@@ -58,7 +59,12 @@
   <TabGroup
     active={$pageState.itemType}
     on:tabChanged={({ detail }) => {
-      pageState.set({ ...$pageState, itemType: detail.active, search: "" });
+      pageState.set({
+        ...$pageState,
+        itemType: detail.active,
+        search: "",
+        page: "",
+      });
     }}
   >
     <Tab key="metrics">Metrics</Tab>

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -63,7 +63,7 @@
         ...$pageState,
         itemType: detail.active,
         search: "",
-        page: "",
+        page: 1,
       });
     }}
   >


### PR DESCRIPTION
Fixes #528 
The thought behind this PR is as follows:
1. Update pagination state if the user navigates to any
2. reset pagination state to 1 when input filter is changed, i.e. display the first page by default
3. Clear the pagination state from url if user jumps to some other page

Also, when un-checking the paginate checkbox on pages 2, 3, .. (any page other than 1), the app ran into `Uncaught (in promise) Error: {#each} only iterates over array-like objects`. This commit fixes this error as well.

Pull Request checklist

- [x] The pull request has a descriptive title (and a reference to an issue it
fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts
