### PR TITLE
Deduplicate metrics (fixes #627)

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -290,6 +290,11 @@ for (app_name, app_group) in app_groups.items():
                 )
             )
 
+            # deduplicate metrics in variants by their app_id
+            app_metrics[metric.identifier]["variants"] = list(
+                {v["app_id"]: v for v in app_metrics[metric.identifier]["variants"]}.values()
+            )
+
         for ping in app.get_pings():
             if ping.identifier not in ping_identifiers_seen:
                 ping_identifiers_seen.add(ping.identifier)

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -290,11 +290,6 @@ for (app_name, app_group) in app_groups.items():
                 )
             )
 
-            # deduplicate metrics in variants by their app_id
-            app_metrics[metric.identifier]["variants"] = list(
-                {v["app_id"]: v for v in app_metrics[metric.identifier]["variants"]}.values()
-            )
-
         for ping in app.get_pings():
             if ping.identifier not in ping_identifiers_seen:
                 ping_identifiers_seen.add(ping.identifier)

--- a/scripts/glean.py
+++ b/scripts/glean.py
@@ -196,31 +196,6 @@ class GleanApp(object):
         logging.info(f"For {self.app_id}, found Glean dependencies: {dependencies}")
         return dependencies
 
-    def deduplicate_metrics(self, metrics):
-        metric_names = set()
-        results = []
-
-        def get_index(name, list):
-            for i in range(len(list)):
-                if list[i][0] == name:
-                    return i
-            return None
-
-        def get_last_date(metric):
-            return metric[1]["history"][-1]["dates"]["last"]
-
-        for item in metrics:
-            if item[0] not in metric_names:
-                metric_names.add(item[0])
-                results.append(item)
-            # get the latest version of a metric if there's a duplicate
-            if item[0] in metric_names and get_last_date(item) > get_last_date(
-                results[get_index(item[0], results)]
-            ):
-                del results[get_index(item[0], results)]
-                results.append(item)
-        return results
-
     def get_metrics(self) -> List[GleanMetric]:
         data = _cache.get_json(GleanApp.METRICS_URL_TEMPLATE.format(self.app["v1_name"]))
         metrics = [
@@ -236,12 +211,20 @@ class GleanApp(object):
                 (d[0], {**d[1], "origin": dependency["library_name"]})
                 for d in dependency_metrics.items()
             ]
-            metrics = self.deduplicate_metrics(metrics)
+            # only get the latest version of metrics
+            deduplicated_metrics = {}
+            for metric in metrics:
+                if (
+                    not deduplicated_metrics.get(metric[0])
+                    or deduplicated_metrics[metric[0]][1]["history"][-1]["dates"]["last"]
+                    < metric[1]["history"][-1]["dates"]["last"]
+                ):
+                    deduplicated_metrics[metric[0]] = metric
 
         ping_names = set(self._get_ping_data().keys())
 
         processed = []
-        for _id, defn in metrics:
+        for _id, defn in deduplicated_metrics.values():
             metric = GleanMetric(_id, defn, ping_names=ping_names)
             processed.append(metric)
 

--- a/scripts/glean.py
+++ b/scripts/glean.py
@@ -211,20 +211,21 @@ class GleanApp(object):
                 (d[0], {**d[1], "origin": dependency["library_name"]})
                 for d in dependency_metrics.items()
             ]
-            # only get the latest version of metrics
-            deduplicated_metrics = {}
-            for metric in metrics:
-                if (
-                    not deduplicated_metrics.get(metric[0])
-                    or deduplicated_metrics[metric[0]][1]["history"][-1]["dates"]["last"]
-                    < metric[1]["history"][-1]["dates"]["last"]
-                ):
-                    deduplicated_metrics[metric[0]] = metric
 
         ping_names = set(self._get_ping_data().keys())
-
         processed = []
-        for _id, defn in deduplicated_metrics.values():
+
+        # deduplicate metrics
+        metric_map = {}
+        for metric in metrics:
+            if (
+                not metric_map.get(metric[0])
+                or metric_map[metric[0]][1]["history"][-1]["dates"]["last"]
+                < metric[1]["history"][-1]["dates"]["last"]
+            ):
+                metric_map[metric[0]] = metric
+
+        for _id, defn in metric_map.values():
             metric = GleanMetric(_id, defn, ping_names=ping_names)
             processed.append(metric)
 


### PR DESCRIPTION
Fixes #627. For example [`app_build`](https://deploy-preview-644--glean-dictionary-dev.netlify.app/apps/fenix/metrics/app_build) is now counted correctly: 

<img width="482" alt="CleanShot 2021-06-03 at 10 31 46@2x" src="https://user-images.githubusercontent.com/28797553/120687627-06c98100-c457-11eb-9cc7-7d12c27a2edd.png">




### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
