### PR TITLE
Better section headings

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -2402,6 +2402,40 @@ exports[`Storyshots Schema Viewer Basic 1`] = `
 </section>
 `;
 
+exports[`Storyshots Sub-heading Default 1`] = `
+<section
+  class="storybook-snapshot-container"
+>
+  <h2
+    class="svelte-1kj38jp"
+  >
+    Commentary
+     
+    <div
+      class="main svelte-rmkku3"
+    >
+      <span
+        class="svelte-rmkku3"
+      >
+        <svg
+          class="w-5 inline-block svelte-1recnuw"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            class="svelte-1recnuw"
+            clip-rule="evenodd"
+            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </span>
+    </div>
+  </h2>
+</section>
+`;
+
 exports[`Storyshots Tab Basic 1`] = `
 <section
   class="storybook-snapshot-container"

--- a/src/components/SubHeading.svelte
+++ b/src/components/SubHeading.svelte
@@ -1,0 +1,19 @@
+<script>
+  import HelpHoverable from "./HelpHoverable.svelte";
+
+  export let title;
+  export let helpText;
+</script>
+
+<h2>
+  {@html title}
+  {#if helpText}
+    <HelpHoverable content={helpText} />
+  {/if}
+</h2>
+
+<style>
+  h2 {
+    @include text-title-xs;
+  }
+</style>

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -11,6 +11,7 @@
   import Label from "../components/Label.svelte";
   import { TabGroup, Tab, TabContent } from "../components/tabs";
   import PageTitle from "../components/PageTitle.svelte";
+  import SubHeading from "../components/SubHeading.svelte";
   import { pageState, pageTitle } from "../state/stores";
 
   export let params;
@@ -53,7 +54,10 @@
     schema={APPLICATION_DEFINITION_SCHEMA}
   />
 
-  <h2>Commentary</h2>
+  <SubHeading
+    title={"Commentary"}
+    helpText={"Reviewed commentary from Mozilla data practitioners on this application."}
+  />
   <Commentary item={app} itemType={"application"} />
 
   <TabGroup

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -9,6 +9,7 @@
   import NotFound from "../components/NotFound.svelte";
   import HelpHoverable from "../components/HelpHoverable.svelte";
   import PageTitle from "../components/PageTitle.svelte";
+  import SubHeading from "../components/SubHeading.svelte";
   import MetadataTable from "../components/MetadataTable.svelte";
   import {
     METRIC_DEFINITION_SCHEMA,
@@ -106,8 +107,6 @@
     ping{metric.send_in_pings.length > 1 ? "s" : ""}.
   </p>
 
-  <h2>Definition</h2>
-
   <MetadataTable
     appName={params.app}
     item={metric}
@@ -135,19 +134,27 @@
       {/each}
     </table>
   {/if}
-  <h2>Metadata</h2>
 
+  <SubHeading
+    title={"Metadata"}
+    helpText={"Metadata about this metric, as defined by the implementor."}
+  />
   <MetadataTable
     appName={params.app}
     item={metric}
     schema={METRIC_METADATA_SCHEMA}
   />
 
-  <h2>Commentary</h2>
+  <SubHeading
+    title={"Commentary"}
+    helpText={"Reviewed commentary from Mozilla data practitioners on this metric."}
+  />
   <Commentary item={metric} itemType={"metric"} />
 
-  <h2>Access</h2>
-
+  <SubHeading
+    title={"Access"}
+    helpText={"Ways to access this metric in Mozilla's data warehouse."}
+  />
   <div class="access-selectors">
     {#if metric.variants.length > 1}
       <div>

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -13,6 +13,7 @@
   import NotFound from "../components/NotFound.svelte";
   import Markdown from "../components/Markdown.svelte";
   import PageTitle from "../components/PageTitle.svelte";
+  import SubHeading from "../components/SubHeading.svelte";
   import { PING_SCHEMA } from "../data/schemas";
 
   export let params;
@@ -46,13 +47,22 @@
     <Markdown text={ping.description} />
   </p>
 
-  <h2>Metadata</h2>
+  <SubHeading
+    title={"Metadata"}
+    helpText={"Metadata about this ping, as defined by the implementor."}
+  />
   <MetadataTable appName={params.app} item={ping} schema={PING_SCHEMA} />
 
-  <h2>Commentary</h2>
+  <SubHeading
+    title={"Commentary"}
+    helpText={"Reviewed commentary from Mozilla data practitioners on this ping."}
+  />
   <Commentary item={ping} itemType={"ping"} />
 
-  <h2>Access</h2>
+  <SubHeading
+    title={"Access"}
+    helpText={"Ways to access this metric in Mozilla's data warehouse."}
+  />
 
   {#if ping.variants.length > 1}
     <VariantSelector
@@ -104,7 +114,10 @@
     </table>
   {/if}
 
-  <h2>Metrics</h2>
+  <SubHeading
+    title={"Metrics"}
+    helpText={"Metrics that are sent inside this ping."}
+  />
   <ItemList itemType="metrics" items={ping.metrics} appName={params.app} />
 {:catch}
   <NotFound pageName={params.ping} itemType="ping" />

--- a/stories/SubHeading.svelte
+++ b/stories/SubHeading.svelte
@@ -1,0 +1,8 @@
+<script>
+  import SubHeading from "../src/components/SubHeading.svelte";
+
+  export let title;
+  export let helpText;
+</script>
+
+<SubHeading {title} {helpText} />

--- a/stories/subheading.stories.js
+++ b/stories/subheading.stories.js
@@ -1,0 +1,18 @@
+import { text } from "@storybook/addon-knobs";
+
+import SubHeading from "./SubHeading.svelte";
+
+export default {
+  title: "Sub-heading",
+};
+
+export const Default = () => ({
+  Component: SubHeading,
+  props: {
+    title: text("Title", "Commentary"),
+    helpText: text(
+      "Help text",
+      "Reviewed commentary from Mozilla data practitioners on this application."
+    ),
+  },
+});


### PR DESCRIPTION
* Remove confusing definition / metadata split in metric view
* Add help for most section headings in metrics, pings, and application
  views

Partially addresses #640
