### PR TITLE
Fix navigation in metrics list

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -23,20 +23,11 @@
   let pagedItems;
   let paginated = true;
 
-  // track change of filter input
-  let { search } = $pageState;
-
-  // re-filter items when showExpired or search text changes
-  $: {
-    if (search !== $pageState.search) {
-      search = $pageState.search || "";
-      $pageState.page = 1;
-    }
-  }
-
   // update pagedItems when either pagination changes or search text changes
   // (above)
   $: {
+    const search = $pageState.search || "";
+
     const originMatch = (item) =>
       item.origin && item.origin.includes(search.toLowerCase());
 
@@ -61,7 +52,7 @@
   }
 
   const originClicked = (origin) => {
-    $pageState = { ...$pageState, search: origin };
+    $pageState = { ...$pageState, search: origin, page: 1 };
     // when the user clicks on an origin (library name), we want to persist a new state
     updateURLState(true);
   };


### PR DESCRIPTION
If you navigated to a subsequent page, then clicked on a library
name, then navigated back you'd be stuck on the current page.

Fix this mostly by simplifying some reactive logic: there's no need
to track/use a seperate `search` variable outside of the reactive
statement itself.
