### PR TITLE
Handle label edge case

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -1821,55 +1821,61 @@ exports[`Storyshots Label Default 1`] = `
   </p>
    
   <span
-    class="label label-1  svelte-b1x4s2"
+    class="label label-0  svelte-17z7aa0"
+  >
+    label-0
+  </span>
+   
+  <span
+    class="label label-1  svelte-17z7aa0"
   >
     label-1
   </span>
    
   <span
-    class="label label-2  svelte-b1x4s2"
+    class="label label-2  svelte-17z7aa0"
   >
     label-2
   </span>
    
   <span
-    class="label label-3  svelte-b1x4s2"
+    class="label label-3  svelte-17z7aa0"
   >
     label-3
   </span>
    
   <span
-    class="label label-4  svelte-b1x4s2"
+    class="label label-4  svelte-17z7aa0"
   >
     label-4
   </span>
    
   <span
-    class="label label-5  svelte-b1x4s2"
+    class="label label-5  svelte-17z7aa0"
   >
     label-5
   </span>
    
   <span
-    class="label label-6  svelte-b1x4s2"
+    class="label label-6  svelte-17z7aa0"
   >
     label-6
   </span>
    
   <span
-    class="label label-7  svelte-b1x4s2"
+    class="label label-7  svelte-17z7aa0"
   >
     label-7
   </span>
    
   <span
-    class="label label-8  svelte-b1x4s2"
+    class="label label-8  svelte-17z7aa0"
   >
     label-8
   </span>
    
   <span
-    class="label label-9  svelte-b1x4s2"
+    class="label label-9  svelte-17z7aa0"
   >
     label-9
   </span>
@@ -1883,49 +1889,49 @@ exports[`Storyshots Label Default 1`] = `
   </h4>
    
   <span
-    class="label label-8  svelte-b1x4s2"
+    class="label label-9  svelte-17z7aa0"
   >
     glean-core
   </span>
    
   <span
-    class="label label-5  svelte-b1x4s2"
+    class="label label-1  svelte-17z7aa0"
   >
     glean-android
   </span>
    
   <span
-    class="label label-4  svelte-b1x4s2"
+    class="label label-5  svelte-17z7aa0"
   >
     sync
   </span>
    
   <span
-    class="label label-3  svelte-b1x4s2"
+    class="label label-5  svelte-17z7aa0"
   >
     lib-crash
   </span>
    
   <span
-    class="label label-8  svelte-b1x4s2"
+    class="label label-6  svelte-17z7aa0"
   >
     engine-gecko
   </span>
    
   <span
-    class="label label-3  svelte-b1x4s2"
+    class="label label-2  svelte-17z7aa0"
   >
     support-migration
   </span>
    
   <span
-    class="label label-6  svelte-b1x4s2"
+    class="label label-4  svelte-17z7aa0"
   >
     nimbus
   </span>
    
   <span
-    class="label label-3  svelte-b1x4s2"
+    class="label label-4  svelte-17z7aa0"
   >
     logins-store
   </span>
@@ -1939,13 +1945,13 @@ exports[`Storyshots Label Default 1`] = `
   </h4>
    
   <span
-    class="label label-9  svelte-b1x4s2"
+    class="label label-9  svelte-17z7aa0"
   >
     deprecated
   </span>
    
   <span
-    class="label label-9  svelte-b1x4s2"
+    class="label label-9  svelte-17z7aa0"
   >
     expired
   </span>

--- a/src/components/Label.svelte
+++ b/src/components/Label.svelte
@@ -16,20 +16,7 @@
     return num;
   };
 
-  const digitSum = (number) => {
-    let sum = 0;
-    let num = number;
-    while (num % 10 !== 0) {
-      sum += Math.floor(num % 10);
-      num /= 10;
-      if (num === 0 && sum >= 10) {
-        num = sum;
-        sum = 0;
-      }
-    }
-    return sum;
-  };
-  const getLabelNumber = (word) => digitSum(a1z26Decoder(word));
+  const getLabelNumber = (word) => a1z26Decoder(word) % 10;
 </script>
 
 <span
@@ -42,6 +29,7 @@
 <style lang="scss">
   // to choose a specific label color in this palette, use $labelNumber variable, otherwise it will be automatically generated
   $color-palette-light: (
+    "0": #eeaaff,
     "1": #77aadd,
     "2": #99ddff,
     "3": #44bb99,
@@ -83,7 +71,7 @@
     box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.12);
   }
 
-  @each $label-number in ("1", "2", "3", "4", "5", "6", "7", "8", "9") {
+  @each $label-number in ("0", "1", "2", "3", "4", "5", "6", "7", "8", "9") {
     @include generateLabelColor($label-number);
   }
 

--- a/stories/Label.svelte
+++ b/stories/Label.svelte
@@ -9,6 +9,7 @@
     >labelNumber</code
   > variable.
 </p>
+<Label labelNumber="0" text="label-0" />
 <Label labelNumber="1" text="label-1" />
 <Label labelNumber="2" text="label-2" />
 <Label labelNumber="3" text="label-3" />


### PR DESCRIPTION
Some labels' styling wouldn't match one of the ones that we
generated, so we'd get a class that wasn't defined (label-0).
Fix this and simplify some logic while we're at it.
