### PR TITLE
Reset pagination if filter text ever changes

### DIFF
--- a/src/components/FilterInput.svelte
+++ b/src/components/FilterInput.svelte
@@ -10,6 +10,10 @@
     type="search"
     id="filter-input"
     bind:value={$pageState.search}
+    on:input={() => {
+      // we want to reset the page number to 1 if the filter text ever changes
+      $pageState.page = 1;
+    }}
   />
 </div>
 


### PR DESCRIPTION
Weird things can happen if you were on a subsequent page and changed
the filter text (up to and including being past the "edge" of where
one is allowed to paginate)
