### PR TITLE
Broader matching when filtering

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -8,6 +8,7 @@
   import Markdown from "./Markdown.svelte";
   import Label from "./Label.svelte";
 
+  import { filterItems } from "../state/filter";
   import { isExpired } from "../state/metrics";
   import { pageState, updateURLState } from "../state/stores";
 
@@ -28,29 +29,12 @@
   // update pagedItems when either pagination changes or search text changes
   // (above)
   $: {
-    const search = ($pageState.search || "").toLowerCase();
-
-    // filter on match either on name, origin, or tag
-    // in all cases a partial match is ok and we'll do a case insensitive
-    // match
-
-    const originMatch = (item) =>
-      item.origin && item.origin.toLowerCase().includes(search);
-
-    const tagMatch = (item) =>
-      item.tags && item.tags.some((tag) => tag.toLowerCase().includes(search));
-
-    filteredItems = items.filter(
-      (item) =>
-        item.name.toLowerCase().includes(search) ||
-        originMatch(item) ||
-        tagMatch(item)
+    // filter items by search terms and expiry state
+    filteredItems = filterItems(
+      items,
+      $pageState.search || "",
+      $pageState.showExpired
     );
-
-    // also filter out expired items (if we're not showing expired)
-    filteredItems = $pageState.showExpired
-      ? filteredItems
-      : filteredItems.filter((item) => !isExpired(item.expires));
 
     // update pagination
     const currentPage = $pageState.page || 1;

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -1,0 +1,26 @@
+import { isExpired } from "./metrics";
+
+export function filterItems(items, search, showExpired) {
+  const searchTokens = search.trim().toLowerCase().split(/\s+/);
+
+  // filter on match either on name, origin, or tag
+  // in all cases a partial match is ok and we'll do a case insensitive
+  // match, but an item has to match *each* of the tokens
+  const originMatch = (item, searchToken) =>
+    item.origin && item.origin.toLowerCase().includes(searchToken);
+
+  const tagMatch = (item, searchToken) =>
+    item.tags &&
+    item.tags.some((tag) => tag.toLowerCase().includes(searchToken));
+
+  return items.filter(
+    (item) =>
+      (showExpired || !isExpired(item.expires)) &&
+      searchTokens.every(
+        (searchToken) =>
+          item.name.toLowerCase().includes(searchToken) ||
+          originMatch(item, searchToken) ||
+          tagMatch(item, searchToken)
+      )
+  );
+}

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -18,7 +18,7 @@ const items = [
     tags: ["TopSites"],
     expires: getDateStr(tomorrow),
   },
-  { name: "metric.camel", expires: getDateStr(tomorrow) },
+  { name: "metric.camel", expires: getDateStr(tomorrow), origin: "glean-core" },
   { name: "metric.expired", expires: getDateStr(yesterday) },
 ];
 
@@ -72,6 +72,23 @@ describe("filters on tag", () => {
   it("handles multi-match", () => {
     expect(getNames(filterItems(items, "top sites", true))).toEqual([
       "metric.bestsitez",
+    ]);
+  });
+});
+
+describe("filters on origin", () => {
+  it("handles single match", () => {
+    expect(getNames(filterItems(items, "glean", true))).toEqual([
+      "metric.camel",
+    ]);
+    expect(getNames(filterItems(items, "core", true))).toEqual([
+      "metric.camel",
+    ]);
+  });
+
+  it("handles multi-match", () => {
+    expect(getNames(filterItems(items, "glean core", true))).toEqual([
+      "metric.camel",
     ]);
   });
 });

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -1,0 +1,85 @@
+import { filterItems } from "../src/state/filter";
+
+const today = new Date();
+const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
+const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
+
+function getDateStr(date) {
+  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+}
+
+function getNames(items) {
+  return items.map((i) => i.name);
+}
+
+const items = [
+  {
+    name: "metric.bestsitez",
+    tags: ["TopSites"],
+    expires: getDateStr(tomorrow),
+  },
+  { name: "metric.camel", expires: getDateStr(tomorrow) },
+  { name: "metric.expired", expires: getDateStr(yesterday) },
+];
+
+describe("filters on name", () => {
+  it("works with empty search", () => {
+    expect(getNames(filterItems(items, "", true))).toEqual([
+      "metric.bestsitez",
+      "metric.camel",
+      "metric.expired",
+    ]);
+  });
+
+  it("works when all match", () => {
+    expect(getNames(filterItems(items, "metric", true))).toEqual([
+      "metric.bestsitez",
+      "metric.camel",
+      "metric.expired",
+    ]);
+  });
+
+  it("works when some match", () => {
+    expect(getNames(filterItems(items, "camel", true))).toEqual([
+      "metric.camel",
+    ]);
+  });
+
+  it("works when none match", () => {
+    expect(getNames(filterItems(items, "nope", true))).toEqual([]);
+  });
+
+  it("handles multiple tokens as you'd expect", () => {
+    expect(getNames(filterItems(items, "best sites", true))).toEqual([
+      "metric.bestsitez",
+    ]);
+    expect(getNames(filterItems(items, "best    sites", true))).toEqual([
+      "metric.bestsitez",
+    ]);
+  });
+});
+
+describe("filters on tag", () => {
+  it("handles single match", () => {
+    expect(getNames(filterItems(items, "to", true))).toEqual([
+      "metric.bestsitez",
+    ]);
+    expect(getNames(filterItems(items, "top", true))).toEqual([
+      "metric.bestsitez",
+    ]);
+  });
+
+  it("handles multi-match", () => {
+    expect(getNames(filterItems(items, "top sites", true))).toEqual([
+      "metric.bestsitez",
+    ]);
+  });
+});
+
+describe("expiry", () => {
+  it("doesn't return expired items when showExpired is false", () =>
+    expect(getNames(filterItems(items, "", false))).toEqual([
+      "metric.bestsitez",
+      "metric.camel",
+    ]));
+});


### PR DESCRIPTION
Split search text by whitespace into a set of tokens, and consider the
term matching if *any* token matches one of metric text, tag, or origin.

Also, extract out filtering logic into a function and write a bunch of tests for it.