### PR TITLE
Show event extra_keys types (fixes #647)

### DIFF
--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -151,6 +151,8 @@
         <tr>
           <td><code>{keyName}</code></td>
           <td>
+            {#if definition.type}<td>Type: <code>{definition.type}</code></td
+              >{/if}
             <Markdown text={definition.description} />
           </td>
         </tr>

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -147,12 +147,14 @@
     <table>
       <col />
       <col />
+      <col />
       {#each Object.entries(metric.extra_keys) as [keyName, definition]}
         <tr>
           <td><code>{keyName}</code></td>
           <td>
-            {#if definition.type}<td>Type: <code>{definition.type}</code></td
-              >{/if}
+            <code>{definition.type || "string"}</code>
+          </td>
+          <td>
             <Markdown text={definition.description} />
           </td>
         </tr>


### PR DESCRIPTION
Fixes #647.

From [this commit](https://github.com/mozilla-mobile/android-components/pull/10421/files#diff-f931f692b73dced5e27d9350c4ce967de7eaddb3ddceec603c3812d5605421fdR921-R927) that @badboy referenced in the issue it looks like [fxa_tab_received](https://deploy-preview-701--glean-dictionary-dev.netlify.app/apps/fenix/metrics/fxa_tab_received) should have the type for the extra keys already, but looks like it hasn't landed on probeinfo yet: https://probeinfo.telemetry.mozilla.org/glean/sync/metrics

```
"extra_keys" : {
  "flow_id": {
    "description": "A guid, unique for the URL being sent but common for all target devices.\n"
  },
  "reason": {
    "description": "The reason we discovered the tab. Will be one of 'push', 'push-missed' or 'poll'.\n"
  },
  "stream_id": {
    "description": "A guid, unique for both the URL being sent and the target device.\n"
  }
},
```
### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
