### PR TITLE
Persist variant state for metric and ping pages (fixes #693)

### DIFF
--- a/src/components/VariantSelector.svelte
+++ b/src/components/VariantSelector.svelte
@@ -1,5 +1,6 @@
 <script>
   import { createEventDispatcher } from "svelte";
+  import { updateURLState, pageState } from "../state/stores";
 
   export let name;
   export let label;
@@ -12,7 +13,19 @@
 
   const change = () => {
     selectedVariant = variants.find((v) => v.id === selectedId);
-
+    $pageState = {
+      ...$pageState,
+      // because both app channel and ping use `id` as the identifier
+      // we check if selectedVariant.channel exists to differentiate
+      // between setting channel and ping state
+      channel: selectedVariant.channel
+        ? selectedVariant.id
+        : $pageState.channel || "",
+      ping: selectedVariant.channel
+        ? $pageState.ping || ""
+        : selectedVariant.id || "",
+    };
+    updateURLState(true);
     dispatch("change");
   };
 </script>

--- a/src/components/VariantSelector.svelte
+++ b/src/components/VariantSelector.svelte
@@ -1,6 +1,5 @@
 <script>
   import { createEventDispatcher } from "svelte";
-  import { updateURLState, pageState } from "../state/stores";
 
   export let name;
   export let label;
@@ -13,19 +12,7 @@
 
   const change = () => {
     selectedVariant = variants.find((v) => v.id === selectedId);
-    $pageState = {
-      ...$pageState,
-      // because both app channel and ping use `id` as the identifier
-      // we check if selectedVariant.channel exists to differentiate
-      // between setting channel and ping state
-      channel: selectedVariant.channel
-        ? selectedVariant.id
-        : $pageState.channel || "",
-      ping: selectedVariant.channel
-        ? $pageState.ping || ""
-        : selectedVariant.id || "",
-    };
-    updateURLState(true);
+
     dispatch("change");
   };
 </script>

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -46,6 +46,15 @@
       selectedAppVariant.etl.ping_data[selectedPingVariant.id];
   }
 
+  $: $pageState =
+    selectedAppVariant && selectedPingVariant
+      ? {
+          ...$pageState,
+          channel: selectedAppVariant.id,
+          ping: selectedPingVariant.id,
+        }
+      : $pageState;
+
   pageTitle.set(`${params.metric} | ${params.app} `);
 
   function getMetricDocumentationURI(type) {

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -17,7 +17,7 @@
     METRIC_METADATA_SCHEMA,
   } from "../data/schemas";
   import { getMetricData } from "../state/api";
-  import { pageTitle } from "../state/stores";
+  import { pageTitle, pageState } from "../state/stores";
   import { getBigQueryURL } from "../state/urls";
 
   import { isExpired } from "../state/metrics";
@@ -29,8 +29,12 @@
   let pingData;
   const metricDataPromise = getMetricData(params.app, params.metric).then(
     (metricData) => {
-      [selectedAppVariant] = metricData.variants;
-      selectedPingVariant = { id: metricData.send_in_pings[0] };
+      [selectedAppVariant] = $pageState.channel
+        ? metricData.variants.filter((app) => app.id === $pageState.channel)
+        : metricData.variants;
+      selectedPingVariant = {
+        id: $pageState.ping ? $pageState.ping : metricData.send_in_pings[0],
+      };
       return metricData;
     }
   );

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -21,7 +21,9 @@
   let selectedAppVariant;
   const pingDataPromise = getPingData(params.app, params.ping).then(
     (pingData) => {
-      [selectedAppVariant] = pingData.variants;
+      [selectedAppVariant] = $pageState.channel
+        ? pingData.variants.filter((app) => app.id === $pageState.channel)
+        : pingData.variants;
       return pingData;
     }
   );

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -33,6 +33,11 @@
     showExpired: true,
     ...$pageState,
   };
+
+  $: $pageState = selectedAppVariant
+    ? { ...$pageState, channel: selectedAppVariant.id }
+    : $pageState;
+
   pageTitle.set(`${params.ping} | ${params.app}`);
 </script>
 


### PR DESCRIPTION
Fixes #693.

Examples:
- Metric page: https://deploy-preview-702--glean-dictionary-dev.netlify.app/apps/fenix/metrics/glean_error_invalid_label?channel=org.mozilla.fenix&ping=bookmarks-sync
- Ping page: https://deploy-preview-702--glean-dictionary-dev.netlify.app/apps/fenix/pings/events?channel=org.mozilla.firefox_beta&showExpired=1

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
