### PR TITLE
Centre-justify cards on main pages

### DIFF
--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -222,6 +222,7 @@
     background-color: inherit;
   }
   #card {
+    justify-self: center;
     max-width: 230px;
     #media-block {
       &:hover {


### PR DESCRIPTION
Very minor tweak that makes the site appear better, especially on
extremely narrow widths (e.g. mobile devices)
