### PR TITLE
Be more specific when a metric is not supported in GLAM

### DIFF
--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -220,7 +220,7 @@
               {params.metric}
             </AuthenticatedLink>
           {:else}
-            GLAM doesn't support <code>{metric.type}</code> metrics yet.
+            Currently GLAM doesn't support <code>{metric.type}</code> metrics.
           {/if}
         </td>
       </tr>

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -206,22 +206,24 @@
     <table>
       <col />
       <col />
-      {#if selectedAppVariant.etl.glam_url}
-        <tr>
-          <td>
-            GLAM
-            <HelpHoverable
-              content={"View this metric in the Glean Aggregated Metrics (GLAM) dashboard"}
-              link={"https://docs.telemetry.mozilla.org/cookbooks/glam.html"}
-            />
-          </td>
-          <td>
+      <tr>
+        <td>
+          GLAM
+          <HelpHoverable
+            content={"View this metric in the Glean Aggregated Metrics (GLAM) dashboard"}
+            link={"https://docs.telemetry.mozilla.org/cookbooks/glam.html"}
+          />
+        </td>
+        <td>
+          {#if selectedAppVariant.etl.glam_url}
             <AuthenticatedLink href={selectedAppVariant.etl.glam_url}>
               {params.metric}
             </AuthenticatedLink>
-          </td>
-        </tr>
-      {/if}
+          {:else}
+            GLAM doesn't support <code>{metric.type}</code> metrics yet.
+          {/if}
+        </td>
+      </tr>
       {#if pingData.looker}
         <tr>
           <td


### PR DESCRIPTION
Recently a user asked in an internal slack channel about why the dictionary doesn't link out to GLAM for `event` metrics. GLAM doesn't support visualizing `event`, but as this is a gotcha that not a lot of people know about, I think it'd be more user-friendly to specifically state that a metric is not supported in GLAM, rather than not showing anything.

Before:
<img width="395" alt="CleanShot 2021-07-23 at 14 52 21@2x" src="https://user-images.githubusercontent.com/28797553/126845029-e81d3bab-cf9c-46dd-ba7c-2b466366fbee.png">


After:

<img width="591" alt="CleanShot 2021-07-23 at 14 51 41@2x" src="https://user-images.githubusercontent.com/28797553/126844992-059ee759-089e-431d-ac01-218b6e82ddb9.png">

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
