### PR TITLE
Don't use a reactive declarations to handle updating the URL

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,7 +17,7 @@
   import GlobalStyles from "./GlobalStyles.svelte";
 
   // Stores
-  import { pageTitle, updatePageState } from "./state/stores";
+  import { pageTitle, replacePageState } from "./state/stores";
 
   let component;
   let params = {};
@@ -61,10 +61,10 @@
 
   function setComponent(c) {
     return function setComponentInner(ctx) {
+      initialState = queryStringParse(ctx.querystring);
+      replacePageState(initialState);
       component = c;
       params = ctx.params;
-      initialState = queryStringParse(ctx.querystring);
-      updatePageState(initialState);
     };
   }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,11 +17,10 @@
   import GlobalStyles from "./GlobalStyles.svelte";
 
   // Stores
-  import { pageTitle, replacePageState } from "./state/stores";
+  import { pageState, pageTitle } from "./state/stores";
 
   let component;
   let params = {};
-  let initialState = {};
   let links = [];
 
   let title;
@@ -61,8 +60,7 @@
 
   function setComponent(c) {
     return function setComponentInner(ctx) {
-      initialState = queryStringParse(ctx.querystring);
-      replacePageState(initialState);
+      pageState.set(queryStringParse(ctx.querystring));
       component = c;
       params = ctx.params;
     };
@@ -114,7 +112,7 @@
   {/if}
   <main>
     <div class="mzp-l-content">
-      <svelte:component this={component} bind:params bind:initialState />
+      <svelte:component this={component} bind:params />
     </div>
   </main>
 

--- a/src/components/FilterInput.svelte
+++ b/src/components/FilterInput.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { pageState, updatePageState } from "../state/stores";
+  import { pageState, updateURLState } from "../state/stores";
 
   export let placeHolder;
 </script>
@@ -13,7 +13,7 @@
     on:input={() => {
       // we want to reset the page number to 1 if the filter text ever changes
       // (and also update the URL)
-      updatePageState({ page: 1 });
+      updateURLState({ page: 1 });
     }}
   />
 </div>

--- a/src/components/FilterInput.svelte
+++ b/src/components/FilterInput.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { pageState } from "../state/stores";
+  import { pageState, updatePageState } from "../state/stores";
 
   export let placeHolder;
 </script>
@@ -12,7 +12,8 @@
     bind:value={$pageState.search}
     on:input={() => {
       // we want to reset the page number to 1 if the filter text ever changes
-      $pageState.page = 1;
+      // (and also update the URL)
+      updatePageState({ page: 1 });
     }}
   />
 </div>

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -10,7 +10,7 @@
 
   import { filterItems } from "../state/filter";
   import { isExpired } from "../state/metrics";
-  import { pageState, updateURLState } from "../state/stores";
+  import { pageState, updatePageState } from "../state/stores";
 
   let DEFAULT_ITEMS_PER_PAGE = 20;
 
@@ -47,11 +47,13 @@
   }
 
   const updateSearch = (origin, type = undefined) => {
-    $pageState = type
-      ? { ...$pageState, search: origin, page: 1, itemType: type }
-      : { ...$pageState, search: origin, page: 1 };
+    updatePageState(
+      type
+        ? { ...$pageState, search: origin, page: 1, itemType: type }
+        : { ...$pageState, search: origin, page: 1 },
+      true
+    );
     // when the user clicks on an origin (library name), we want to persist a new state
-    updateURLState(true);
     // reset scroll position if we've scrolled down
     if (scrollY > topElement.offsetTop) {
       window.scroll(0, topElement.offsetTop);

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -53,7 +53,6 @@
         : { ...$pageState, search: origin, page: 1 },
       true
     );
-    // when the user clicks on an origin (library name), we want to persist a new state
     // reset scroll position if we've scrolled down
     if (scrollY > topElement.offsetTop) {
       window.scroll(0, topElement.offsetTop);

--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { pageState } from "../state/stores";
+  import { pageState, updatePageState } from "../state/stores";
 
   import BackButton from "./icons/BackButton.svelte";
   import ForwardButton from "./icons/ForwardButton.svelte";
@@ -38,7 +38,7 @@
   function changePage(page) {
     if (page !== currentPage) {
       currentPage = page;
-      $pageState.page = page;
+      updatePageState({ page });
     }
   }
 

--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { pageState, updatePageState } from "../state/stores";
+  import { pageState, updateURLState } from "../state/stores";
 
   import BackButton from "./icons/BackButton.svelte";
   import ForwardButton from "./icons/ForwardButton.svelte";
@@ -38,7 +38,7 @@
   function changePage(page) {
     if (page !== currentPage) {
       currentPage = page;
-      updatePageState({ page });
+      updateURLState({ page });
     }
   }
 

--- a/src/components/SchemaViewer.svelte
+++ b/src/components/SchemaViewer.svelte
@@ -11,11 +11,12 @@
   let nodesWithVisibility = [];
 
   $: {
-    const { search } = $pageState;
-    const filterTerms = search
-      .trim()
-      .split(" ")
-      .filter((t) => t.length > 0);
+    const filterTerms = $pageState.search
+      ? $pageState.search
+          .trim()
+          .split(" ")
+          .filter((t) => t.length > 0)
+      : [];
 
     const addVisibility = (node, parentNodeNames = ["__root__"]) => {
       let modifiedNode = node;

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -12,22 +12,19 @@
   import { TabGroup, Tab, TabContent } from "../components/tabs";
   import PageTitle from "../components/PageTitle.svelte";
   import SubHeading from "../components/SubHeading.svelte";
-  import { pageState, pageTitle, updatePageState } from "../state/stores";
+  import { pageState, pageTitle, updateURLState } from "../state/stores";
 
   export let params;
-  export let initialState;
 
-  $pageState = {
-    itemType: "metrics",
-    page: 1,
-    search: "",
-    showExpired: true,
-    ...initialState,
-  };
+  let itemType;
 
   const appDataPromise = getAppData(params.app).then((app) => {
     return app;
   });
+
+  $: {
+    itemType = $pageState.itemType || "metrics";
+  }
 
   pageTitle.set(params.app);
 </script>
@@ -64,9 +61,9 @@
   <Commentary item={app} itemType={"application"} />
 
   <TabGroup
-    bind:active={$pageState.itemType}
+    bind:active={itemType}
     on:tabChanged={({ detail }) => {
-      updatePageState({
+      updateURLState({
         itemType: detail.active,
         search: "",
         page: 1,

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -12,18 +12,20 @@
   import { TabGroup, Tab, TabContent } from "../components/tabs";
   import PageTitle from "../components/PageTitle.svelte";
   import SubHeading from "../components/SubHeading.svelte";
-  import { pageState, pageTitle } from "../state/stores";
+  import { pageState, pageTitle, updatePageState } from "../state/stores";
 
   export let params;
+  export let initialState;
+
+  $pageState = {
+    itemType: "metrics",
+    page: 1,
+    search: "",
+    showExpired: true,
+    ...initialState,
+  };
 
   const appDataPromise = getAppData(params.app).then((app) => {
-    $pageState = {
-      itemType: "metrics",
-      page: 1,
-      search: "",
-      showExpired: true,
-      ...$pageState,
-    };
     return app;
   });
 
@@ -64,8 +66,7 @@
   <TabGroup
     bind:active={$pageState.itemType}
     on:tabChanged={({ detail }) => {
-      pageState.set({
-        ...$pageState,
+      updatePageState({
         itemType: detail.active,
         search: "",
         page: 1,

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -12,11 +12,6 @@
 
   const URL = "data/apps.json";
 
-  $pageState = {
-    search: "",
-    ...$pageState,
-  };
-
   let apps;
   let filteredApps;
 
@@ -36,7 +31,7 @@
       filteredApps = apps.filter((appItem) =>
         appItem.canonical_app_name
           .toLowerCase()
-          .includes($pageState.search.toLowerCase())
+          .includes(($pageState.search || "").toLowerCase())
       );
     }
   }

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -17,7 +17,7 @@
     METRIC_METADATA_SCHEMA,
   } from "../data/schemas";
   import { getMetricData } from "../state/api";
-  import { pageTitle, pageState, updatePageState } from "../state/stores";
+  import { pageTitle, pageState, updateURLState } from "../state/stores";
   import { getBigQueryURL } from "../state/urls";
 
   import { isExpired } from "../state/metrics";
@@ -181,7 +181,7 @@
           name={"app_id"}
           label={"Application Variant"}
           bind:selectedVariant={selectedAppVariant}
-          on:change={() => updatePageState({ channel: selectedAppVariant.id })}
+          on:change={() => updateURLState({ channel: selectedAppVariant.id })}
           variants={metric.variants}
         />
       </div>
@@ -193,7 +193,7 @@
           name={"ping_id"}
           label={"Ping"}
           bind:selectedVariant={selectedPingVariant}
-          on:change={() => updatePageState({ ping: selectedPingVariant.id })}
+          on:change={() => updateURLState({ ping: selectedPingVariant.id })}
           variants={metric.send_in_pings.map((p) => ({ id: p }))}
         />
       </div>

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -17,7 +17,7 @@
     METRIC_METADATA_SCHEMA,
   } from "../data/schemas";
   import { getMetricData } from "../state/api";
-  import { pageTitle, pageState } from "../state/stores";
+  import { pageTitle, pageState, updatePageState } from "../state/stores";
   import { getBigQueryURL } from "../state/urls";
 
   import { isExpired } from "../state/metrics";
@@ -26,7 +26,8 @@
 
   let selectedAppVariant;
   let selectedPingVariant;
-  let pingData;
+  let pingData = {};
+
   const metricDataPromise = getMetricData(params.app, params.metric).then(
     (metricData) => {
       [selectedAppVariant] = $pageState.channel
@@ -45,15 +46,6 @@
       selectedPingVariant &&
       selectedAppVariant.etl.ping_data[selectedPingVariant.id];
   }
-
-  $: $pageState =
-    selectedAppVariant && selectedPingVariant
-      ? {
-          ...$pageState,
-          channel: selectedAppVariant.id,
-          ping: selectedPingVariant.id,
-        }
-      : $pageState;
 
   pageTitle.set(`${params.metric} | ${params.app} `);
 
@@ -189,6 +181,7 @@
           name={"app_id"}
           label={"Application Variant"}
           bind:selectedVariant={selectedAppVariant}
+          on:change={() => updatePageState({ channel: selectedAppVariant.id })}
           variants={metric.variants}
         />
       </div>
@@ -200,6 +193,7 @@
           name={"ping_id"}
           label={"Ping"}
           bind:selectedVariant={selectedPingVariant}
+          on:change={() => updatePageState({ ping: selectedPingVariant.id })}
           variants={metric.send_in_pings.map((p) => ({ id: p }))}
         />
       </div>

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -1,6 +1,6 @@
 <script>
   import { getPingData } from "../state/api";
-  import { pageState, pageTitle } from "../state/stores";
+  import { pageState, pageTitle, updatePageState } from "../state/stores";
   import { getBigQueryURL } from "../state/urls";
 
   import AppAlert from "../components/AppAlert.svelte";
@@ -17,6 +17,7 @@
   import { PING_SCHEMA } from "../data/schemas";
 
   export let params;
+  export let initialState;
 
   let selectedAppVariant;
   const pingDataPromise = getPingData(params.app, params.ping).then(
@@ -31,12 +32,8 @@
   $pageState = {
     search: "",
     showExpired: true,
-    ...$pageState,
+    ...initialState,
   };
-
-  $: $pageState = selectedAppVariant
-    ? { ...$pageState, channel: selectedAppVariant.id }
-    : $pageState;
 
   pageTitle.set(`${params.ping} | ${params.app}`);
 </script>
@@ -76,6 +73,7 @@
       name={"app_id"}
       label={"Application Variant"}
       bind:selectedVariant={selectedAppVariant}
+      on:change={() => updatePageState({ channel: selectedAppVariant.id })}
       variants={ping.variants}
     />
   {/if}

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -1,6 +1,6 @@
 <script>
   import { getPingData } from "../state/api";
-  import { pageState, pageTitle, updatePageState } from "../state/stores";
+  import { pageState, pageTitle, updateURLState } from "../state/stores";
   import { getBigQueryURL } from "../state/urls";
 
   import AppAlert from "../components/AppAlert.svelte";
@@ -17,7 +17,6 @@
   import { PING_SCHEMA } from "../data/schemas";
 
   export let params;
-  export let initialState;
 
   let selectedAppVariant;
   const pingDataPromise = getPingData(params.app, params.ping).then(
@@ -28,12 +27,6 @@
       return pingData;
     }
   );
-
-  $pageState = {
-    search: "",
-    showExpired: true,
-    ...initialState,
-  };
 
   pageTitle.set(`${params.ping} | ${params.app}`);
 </script>
@@ -73,7 +66,7 @@
       name={"app_id"}
       label={"Application Variant"}
       bind:selectedVariant={selectedAppVariant}
-      on:change={() => updatePageState({ channel: selectedAppVariant.id })}
+      on:change={() => updateURLState({ channel: selectedAppVariant.id })}
       variants={ping.variants}
     />
   {/if}

--- a/src/pages/TableDetail.svelte
+++ b/src/pages/TableDetail.svelte
@@ -1,19 +1,15 @@
 <script>
   import SchemaViewer from "../components/SchemaViewer.svelte";
   import { getTableData } from "../state/api";
-  import { pageState, pageTitle } from "../state/stores";
+  import { pageTitle } from "../state/stores";
 
   import NotFound from "../components/NotFound.svelte";
   import PageTitle from "../components/PageTitle.svelte";
 
   export let params;
-  export let initialState;
 
   const pingDataPromise = getTableData(params.app, params.appId, params.table);
 
-  $pageState = {
-    ...initialState,
-  };
   pageTitle.set(`${params.table} table | ${params.appId}`);
 </script>
 

--- a/src/pages/TableDetail.svelte
+++ b/src/pages/TableDetail.svelte
@@ -7,12 +7,12 @@
   import PageTitle from "../components/PageTitle.svelte";
 
   export let params;
+  export let initialState;
 
   const pingDataPromise = getTableData(params.app, params.appId, params.table);
 
   $pageState = {
-    search: "",
-    ...$pageState,
+    ...initialState,
   };
   pageTitle.set(`${params.table} table | ${params.appId}`);
 </script>

--- a/src/state/stores.js
+++ b/src/state/stores.js
@@ -5,18 +5,27 @@ import { writable, get } from "svelte/store";
 export const pageTitle = writable("");
 export const pageState = writable({});
 
-// updates page state and synchronizes with the url
-export const updatePageState = (newState, push = false) => {
-  const mergedState = mapValues(
+// simplifies the page state (removing redundant values)
+// before updating the store
+const setPageState = (newState) => {
+  pageState.set(mapValues(
     pickBy(
       { ...get(pageState), ...newState },
-      (v) =>
-        (typeof v !== "string" && v) ||
-        (v && ((v.length > 0 && v !== "page") || v !== "1"))
+      (v) => (typeof v !== "string" && v) || v.length > 0
     ),
     (v) => (typeof v === "boolean" ? +v : v)
   );
-  pageState.set(mergedState);
+};
+
+// replaces the existing page state
+export const replacePageState = (newState) => {
+  setPageState(newState);
+};
+
+// updates page state and synchronizes with the url
+export const updatePageState = (newState, push = false) => {
+  const mergedState = { ...get(pageState), ...newState };
+  setPageState(mergedState);
 
   // convert the state into a query string like "a=b&c=d" and attach it
   // to the URL

--- a/src/state/stores.js
+++ b/src/state/stores.js
@@ -1,21 +1,27 @@
 import { mapValues, pickBy } from "lodash";
 import { stringify } from "query-string";
-import { get, writable } from "svelte/store";
+import { writable, get } from "svelte/store";
 
 export const pageTitle = writable("");
 export const pageState = writable({});
 
-// synchronizes url state with page state
-export const updateURLState = (push = false) => {
-  const simplifiedState = mapValues(
-    pickBy(get(pageState), (v) => (typeof v !== "string" && v) || v.length > 0),
+// updates page state and synchronizes with the url
+export const updatePageState = (newState, push = false) => {
+  const mergedState = mapValues(
+    pickBy(
+      { ...get(pageState), ...newState },
+      (v) =>
+        (typeof v !== "string" && v) ||
+        (v && ((v.length > 0 && v !== "page") || v !== "1"))
+    ),
     (v) => (typeof v === "boolean" ? +v : v)
   );
+  pageState.set(mergedState);
+
   // convert the state into a query string like "a=b&c=d" and attach it
   // to the URL
-  const query = stringify(simplifiedState);
+  const query = stringify(mergedState);
   const path = `${window.location.pathname}${query ? `?${query}` : ""}`;
-
   // in response to some actions, we want to explicitly add a url to the
   // page history
   if (push) {

--- a/src/state/stores.js
+++ b/src/state/stores.js
@@ -5,31 +5,18 @@ import { writable, get } from "svelte/store";
 export const pageTitle = writable("");
 export const pageState = writable({});
 
-// simplifies the page state (removing redundant values)
-// before updating the store
-const setPageState = (newState) => {
-  pageState.set(mapValues(
-    pickBy(
-      { ...get(pageState), ...newState },
-      (v) => (typeof v !== "string" && v) || v.length > 0
-    ),
-    (v) => (typeof v === "boolean" ? +v : v)
-  );
-};
-
-// replaces the existing page state
-export const replacePageState = (newState) => {
-  setPageState(newState);
-};
-
 // updates page state and synchronizes with the url
-export const updatePageState = (newState, push = false) => {
+export const updateURLState = (newState, push = false) => {
   const mergedState = { ...get(pageState), ...newState };
-  setPageState(mergedState);
+  pageState.set(mergedState);
 
   // convert the state into a query string like "a=b&c=d" and attach it
   // to the URL
-  const query = stringify(mergedState);
+  const simplifiedState = mapValues(
+    pickBy(mergedState, (v) => typeof v !== "string" || v.length > 0),
+    (v) => (typeof v === "boolean" ? +v : v)
+  );
+  const query = stringify(simplifiedState);
   const path = `${window.location.pathname}${query ? `?${query}` : ""}`;
   // in response to some actions, we want to explicitly add a url to the
   // page history


### PR DESCRIPTION
It's unreliable during page navigation and often causes us to persist
unwanted state and weird bugs. The basic problem is that navigation
(and the subsequent updating of page state) can trigger a reactive
statement inside a component we're navigating *away* from.

Instead, let's explicitly make a call to update the page state when we need
to, which will also update the URL. It's a little less elegant
but at least it seems to work.
