### PR TITLE
Correction for Glean live data paths

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -437,7 +437,7 @@ for (app_name, app_group) in app_groups.items():
             # write table description (app variant specific)
             ping_name_snakecase = stringcase.snakecase(ping.identifier)
             stable_ping_table_name = f"{app.app['bq_dataset_family']}.{ping_name_snakecase}"
-            live_ping_table_name = f"{app.app['bq_dataset_family']}_live_v1.{ping_name_snakecase}"
+            live_ping_table_name = f"{app.app['bq_dataset_family']}_live.{ping_name_snakecase}_v1"
             bq_path = f"{app.app['document_namespace']}/{ping.identifier}/{ping.identifier}.1.bq"
             bq_definition = (
                 "https://github.com/mozilla-services/mozilla-pipeline-schemas/blob/generated-schemas/schemas/"  # noqa


### PR DESCRIPTION
The `_v1` suffix should be on the table part of the name rather than the dataset.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
