### PR TITLE
Restore boolean (and numeric) properties stored in URL state

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -60,7 +60,7 @@
 
   function setComponent(c) {
     return function setComponentInner(ctx) {
-      pageState.set(queryStringParse(ctx.querystring));
+      pageState.set(queryStringParse(ctx.querystring, { parseNumbers: true }));
       component = c;
       params = ctx.params;
     };

--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -53,7 +53,7 @@
   }
 
   $: {
-    currentPage = Number($pageState.page || 1);
+    currentPage = $pageState.page || 1;
   }
 </script>
 


### PR DESCRIPTION
We were processing them as strings, which meant they weren't being
incorporated as page state correctly. Follow up for:
https://github.com/mozilla/glean-dictionary/pull/780
