### PR TITLE
Improve handling of annotations with no commentary

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -77,7 +77,7 @@ def _get_annotation(annotations_index, origin, item_type, identifier=None):
 
 
 def _incorporate_annotation(item, annotation, app=False, full=False):
-    incorporated = dict(item, has_annotation=len(annotation) > 1)
+    incorporated = dict(item, has_annotation=len(annotation) > 0)
 
     if not app:
         # application "tags" are in a slightly different format than

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -77,7 +77,7 @@ def _get_annotation(annotations_index, origin, item_type, identifier=None):
 
 
 def _incorporate_annotation(item, annotation, app=False, full=False):
-    incorporated = dict(item)
+    incorporated = dict(item, has_annotation=True)
 
     if not app:
         # application "tags" are in a slightly different format than
@@ -85,12 +85,9 @@ def _incorporate_annotation(item, annotation, app=False, full=False):
         # tags (FIXME: define this in a slightly clearer way)
         incorporated.update({"tags": annotation.get("tags", [])})
     if full:
-        incorporated.update(
-            {
-                "commentary": annotation.get("content"),
-                "warning": annotation.get("warning"),
-            }
-        )
+        for annotation_type in ["commentary", "warning"]:
+            if annotation.get(annotation_type):
+                incorporated[annotation_type] = annotation[annotation_type]
 
     return incorporated
 

--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -77,7 +77,7 @@ def _get_annotation(annotations_index, origin, item_type, identifier=None):
 
 
 def _incorporate_annotation(item, annotation, app=False, full=False):
-    incorporated = dict(item, has_annotation=True)
+    incorporated = dict(item, has_annotation=len(annotation) > 1)
 
     if not app:
         # application "tags" are in a slightly different format than

--- a/src/components/Commentary.svelte
+++ b/src/components/Commentary.svelte
@@ -5,28 +5,26 @@
   export let itemType;
   export let item;
 
-  let annotationPath =
+  const annotationPath =
     itemType === "application"
       ? `${item.app_name}/README.md`
       : `${item.origin}/${itemType}s/${item.name}/README.md`;
+  const editLink = item.has_annotation
+    ? `https://github.com/mozilla/glean-annotations/edit/main/annotations/${annotationPath}`
+    : `https://github.com/mozilla/glean-annotations/new/main?filename=annotations/${annotationPath}&value=${encodeURIComponent(
+        defaultAnnotation
+      )}`;
 </script>
 
 {#if item.commentary}
   <Markdown text={item.commentary} inline={false} />
   <p>
-    <a
-      href={`https://github.com/mozilla/glean-annotations/edit/main/annotations/${annotationPath}`}
-      >Edit</a
-    >
+    <a href={editLink}>Edit</a>
   </p>
 {:else}
   <p>
     No commentary for this
     {itemType},
-    <a
-      href={`https://github.com/mozilla/glean-annotations/new/main?filename=annotations/${annotationPath}&value=${encodeURIComponent(
-        defaultAnnotation
-      )}`}>add some</a
-    >?
+    <a href={editLink}>add some</a>?
   </p>
 {/if}


### PR DESCRIPTION
Show the placeholder text in this case, but still allow the user to
edit the annotation on GitHub. Complements https://github.com/mozilla/glean-annotations/pull/67
