### PR TITLE
Make it more clear if metric is removed (fixes #705)

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -242,6 +242,7 @@ for (app_name, app_group) in app_groups.items():
                     dict(
                         name=metric.identifier,
                         description=metric.description,
+                        in_source=metric.definition["in_source"],
                         extra_keys=metric.definition["extra_keys"]
                         if "extra_keys" in metric.definition
                         else None,

--- a/scripts/glean.py
+++ b/scripts/glean.py
@@ -39,6 +39,7 @@ class GleanObject(object):
     NAME_KEY = "name"
     ORIGIN_KEY = "origin"
     HISTORY_KEY = "history"
+    IN_SOURCE_KEY = "in-source"
 
 
 class GleanMetric(GleanObject):
@@ -79,6 +80,7 @@ class GleanMetric(GleanObject):
         self.definition = self.definition_history[0]
         self.definition["name"] = full_defn[self.NAME_KEY]
         self.definition["origin"] = full_defn[self.ORIGIN_KEY]
+        self.definition["in_source"] = full_defn[self.IN_SOURCE_KEY]
 
     def _set_dates(self, definition: dict):
         vals = [datetime.fromisoformat(d["dates"]["first"]) for d in definition[self.HISTORY_KEY]]

--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -584,7 +584,7 @@ exports[`Storyshots ItemList Default 1`] = `
           type="checkbox"
         />
         
-          Show expired metrics
+          Show expired and removed metrics
       </label>
        
       <label

--- a/src/components/Label.svelte
+++ b/src/components/Label.svelte
@@ -3,8 +3,8 @@
   export let labelNumber;
   export let clickable = false;
 
-  // gray color if it's a deprecated/expired label
-  if (text === "deprecated" || text === "expired") {
+  // gray color if it's a deprecated/expired/removed label
+  if (text === "deprecated" || text === "expired" || text === "removed") {
     labelNumber = 9;
   }
 

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -78,10 +78,15 @@
 </script>
 
 {#await metricDataPromise then metric}
-  {#if isExpired(metric.expires)}
+  {#if !metric.in_source}
     <AppAlert
       status="warning"
-      message="This metric has expired: it may not be present in the source code, new data will not be ingested into BigQuery, and it will not appear in dashboards."
+      message={"This metric is no longer defined in the source code: new data will not be collected by the application."}
+    />
+  {:else if isExpired(metric.expires)}
+    <AppAlert
+      status="warning"
+      message={"This metric has expired: new data will not be collected by the application."}
     />
   {/if}
 

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -1,4 +1,6 @@
 import { isExpired } from "./metrics";
 
-export const filterExpiredItems = (items, showExpired) =>
-  items.filter((item) => showExpired || !isExpired(item.expires));
+export const filterUncollectedItems = (items, showUncollected) =>
+  items.filter(
+    (item) => showUncollected || (!isExpired(item.expires) && item.in_source)
+  );

--- a/stories/itemlist.stories.js
+++ b/stories/itemlist.stories.js
@@ -6,6 +6,7 @@ const testData = {
     name: `test metric ${i}`,
     description: `This is test metric ${i}`,
     type: `metric_type`,
+    in_source: true,
   })),
 };
 export default {

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -1,4 +1,4 @@
-import { filterExpiredItems } from "../src/state/filter";
+import { filterUncollectedItems } from "../src/state/filter";
 
 const today = new Date();
 const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
@@ -17,14 +17,21 @@ const items = [
     name: "metric.bestsitez",
     tags: ["TopSites"],
     expires: getDateStr(tomorrow),
+    in_source: true,
   },
-  { name: "metric.camel", expires: getDateStr(tomorrow), origin: "glean-core" },
-  { name: "metric.expired", expires: getDateStr(yesterday) },
+  {
+    name: "metric.camel",
+    expires: getDateStr(tomorrow),
+    origin: "glean-core",
+    in_source: true,
+  },
+  { name: "metric.expired", expires: getDateStr(yesterday), in_source: true },
+  { name: "metric.removed", expires: getDateStr(tomorrow), in_source: false },
 ];
 
 describe("expiry", () => {
-  it("doesn't return expired items when showExpired is false", () =>
-    expect(getNames(filterExpiredItems(items, false))).toEqual([
+  it("doesn't return expired or removed items when showUncollected is false", () =>
+    expect(getNames(filterUncollectedItems(items, false))).toEqual([
       "metric.bestsitez",
       "metric.camel",
     ]));


### PR DESCRIPTION
"Expired" and "removed" are often the same, but not always (e.g.
https://glean-dictionary-dev.netlify.app/apps/fenix/metrics/credit_cards_autofill_card
is not due to expire for quite some time, but has been removed from the
source code)
