### PR TITLE
Better ordering of applications on main page (fixes #456)

### DIFF
--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -25,9 +25,14 @@
     filteredApps = apps;
   });
 
+  const appOrder = ["firefox_ios", "fenix", "firefox_desktop"];
+
   $: {
     // update page state when user filters something
     if (apps) {
+      apps.sort(
+        (a, b) => appOrder.indexOf(b.app_name) - appOrder.indexOf(a.app_name)
+      );
       filteredApps = apps.filter((appItem) =>
         appItem.canonical_app_name
           .toLowerCase()

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -11,6 +11,7 @@
   import { pageState, pageTitle } from "../state/stores";
 
   const URL = "data/apps.json";
+  const APP_SORT_ORDER = ["firefox_ios", "fenix", "firefox_desktop"];
 
   let apps;
   let filteredApps;
@@ -22,17 +23,16 @@
         ? 1
         : -1
     );
+    apps.sort(
+      (a, b) =>
+        APP_SORT_ORDER.indexOf(b.app_name) - APP_SORT_ORDER.indexOf(a.app_name)
+    );
     filteredApps = apps;
   });
-
-  const appOrder = ["firefox_ios", "fenix", "firefox_desktop"];
 
   $: {
     // update page state when user filters something
     if (apps) {
-      apps.sort(
-        (a, b) => appOrder.indexOf(b.app_name) - appOrder.indexOf(a.app_name)
-      );
       filteredApps = apps.filter((appItem) =>
         appItem.canonical_app_name
           .toLowerCase()


### PR DESCRIPTION
We display a manually-curated order of applications for now:

1. Firefox Desktop
2. Firefox Android
3. Firefox iOS

<img width="871" alt="CleanShot 2021-09-16 at 13 49 31@2x" src="https://user-images.githubusercontent.com/28797553/133683790-340a55df-fc09-4242-b21f-e43c59b0e0db.png">
### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
