### PR TITLE
Remove last of markdown reformatting of HTML (fixes #642)

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -2038,17 +2038,18 @@ exports[`Storyshots Markdown Text 1`] = `
 </section>
 `;
 
-exports[`Storyshots Markdown Text With Angle Brackets 1`] = `
+exports[`Storyshots Markdown Text With HTML 1`] = `
 <section
   class="storybook-snapshot-container"
 >
   <p>
-    A &lt;text&gt; in
-  </p>
-  
-
-  <p>
-    markdown &lt;&gt; with angle &lt;brackets&gt; (unquoted) and more angle 
+    Markdown with inline 
+    <span
+      style="color: blue"
+    >
+      HTML
+    </span>
+     (unquoted) and more angle 
     <code>
       &lt;brackets&gt;
     </code>

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -19,8 +19,6 @@
   export let text;
   // if inline is set, do not wrap the markdown in a paragraph -- useful for short snippets
   export let inline = true;
-  console.log(text);
-  console.log(parse(text));
 </script>
 
 {#if inline}

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -13,17 +13,14 @@
         start ? `start="${start}"` : ""
       } class="mzp-u-list-styled">${body}</${outerEl}>`;
     },
-    html(html) {
-      // convert markdown with angle brackets to html,
-      // but escape <mark> tags so we can highlight search results
-      return `${html.replace("/<[^mark]+/g", "&lt;")}`;
-    },
   };
   use({ renderer });
 
   export let text;
   // if inline is set, do not wrap the markdown in a paragraph -- useful for short snippets
   export let inline = true;
+  console.log(text);
+  console.log(parse(text));
 </script>
 
 {#if inline}

--- a/stories/markdown.stories.js
+++ b/stories/markdown.stories.js
@@ -3,8 +3,8 @@ import Markdown from "../src/components/Markdown.svelte";
 
 const mark =
   "A *text* in markdown [moz](https://mozilla.org).\n\nA list:\n\n* Lorem\n* Ipsum\n\nThis is an ordered list starting from 2:\n\n2. Foo\n3. Bar";
-const markWithBracket =
-  "A <text> in\n\nmarkdown <> with angle <brackets> (unquoted) and more angle `<brackets>` (quoted)";
+const markdownWithHTML =
+  'Markdown with inline <span style="color: blue">HTML</span> (unquoted) and more angle `<brackets>` (quoted)';
 
 const inline = false;
 
@@ -20,10 +20,13 @@ export const Text = () => ({
   },
 });
 
-export const TextWithAngleBrackets = () => ({
+export const TextWithHTML = () => ({
   Component: Markdown,
+  parameters: {
+    knobs: { escapeHTML: false },
+  },
   props: {
-    text: text("text", markWithBracket),
+    text: markdownWithHTML, // knobs don't allow unescaped text
     inline: boolean("inline", inline),
   },
 });


### PR DESCRIPTION
To make it less likely that people will accidentally throw in an HTML tag,
we could possibly check inside the glean parser for valid HTML, where it
is specified: https://bugzilla.mozilla.org/show_bug.cgi?id=1733256
