### PR TITLE
Set CORS headers to allow all for /data/*

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,10 @@ publish = "public"
 [context.production]
   [context.production.environment]
   CONTEXT = "production"
+
+
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "/data/*"
+    [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
This will allow GLAM to use the Glean Dictionary as an API (see: https://github.com/mozilla/glam/issues/1581)
