### PR TITLE
Render event extra descriptions as non-inline

### DIFF
--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -151,7 +151,7 @@
             <code>{definition.type || "string"}</code>
           </td>
           <td>
-            <Markdown text={definition.description} />
+            <Markdown text={definition.description} inline={false} />
           </td>
         </tr>
       {/each}


### PR DESCRIPTION
They can contain markdown which gets stripped unless we display them as
"full". We have the space for the full description.
