### PR TITLE
Reference ping count for metrics of ping that does not send a client id (fixes #873)

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -258,7 +258,7 @@ for (app_name, app_group) in app_groups.items():
             json.dumps(app.app)
         )
 
-        pings_with_client_id = []
+        pings_with_client_id = set()
         # ping data
         for ping in app.get_pings():
             if ping.identifier not in ping_identifiers_seen:
@@ -280,7 +280,7 @@ for (app_name, app_group) in app_groups.items():
             ping_data = next(pd for pd in app_data["pings"] if pd["name"] == ping.identifier)
 
             if ping_data["include_client_id"]:
-                pings_with_client_id.append(ping_data["name"])
+                pings_with_client_id.add(ping_data["name"])
 
             # write table description (app variant specific)
             ping_name_snakecase = stringcase.snakecase(ping.identifier)


### PR DESCRIPTION
For pings that do not send a client id, the Looker links for their metrics now reference measure `ping_count` instead of `client` count.

Example of pings that do not send a client id:

- [address-sync](https://deploy-preview-899--glean-dictionary-dev.netlify.app/apps/fenix/pings/addresses-sync)
https://deploy-preview-899--glean-dictionary-dev.netlify.app/apps/fenix/metrics/app_build?ping=addresses-sync

- [background-update](https://deploy-preview-899--glean-dictionary-dev.netlify.app/apps/firefox_desktop_background_update/pings/background-update)
https://deploy-preview-899--glean-dictionary-dev.netlify.app/apps/firefox_desktop_background_update/metrics/background_update_client_id

After:

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
