### PR TITLE
Use a slightly tighter redirect

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,1 @@
-/*    /index.html   200
+/apps/*    /index.html   200


### PR DESCRIPTION
The only valid user-facing URLs for the Glean Dictionary are currently
`/` and `/apps/`. Instead of blanket redirecting everything that comes
up as 404 to `/`, restrict the redirection to `/apps/`. This should
clean up netlify analytics slightly.
