### PR TITLE
Bump netlify python version to 3.8

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@ command = """
       mv storybook-static public/storybook
     fi
 """
-environment = { PYTHON_VERSION = "3.7" }
+environment = { PYTHON_VERSION = "3.8" }
 publish = "public"
 
 [context.production]


### PR DESCRIPTION
Since we're using the 20.04 image now, which doesn't have python 3.7.
