### PR TITLE
Modularize build-glean-metadata script

### DIFF
--- a/scripts/bigquery.py
+++ b/scripts/bigquery.py
@@ -1,0 +1,16 @@
+import stringcase
+
+
+def get_bigquery_ping_table_name(dataset_name, ping_name):
+    ping_name_snakecase = stringcase.snakecase(ping_name)
+    return f"{dataset_name}.{ping_name_snakecase}"
+
+
+def get_bigquery_column_name(metric):
+    metric_type = metric.definition["type"]
+    metric_name_snakecase = stringcase.snakecase(metric.identifier)
+    return (
+        f"{metric.bq_prefix}.{metric_name_snakecase}"
+        if metric.bq_prefix
+        else f"metrics.{metric_type}.{metric_name_snakecase}"
+    )

--- a/scripts/glam.py
+++ b/scripts/glam.py
@@ -1,0 +1,77 @@
+import re
+
+from glean import GLEAN_DISTRIBUTION_TYPES
+
+GLAM_PRODUCT_MAPPINGS = {
+    "org.mozilla.fenix": ("fenix", ""),
+    "org.mozilla.firefox_beta": ("fenix", "beta"),
+    "org.mozilla.firefox": ("fenix", "release"),
+}
+
+# supported glam metric types, from:
+# https://github.com/mozilla/bigquery-etl/blob/c48ab6649448cdf41191f6c24cb00fe46ca2323d/bigquery_etl/glam/clients_daily_histogram_aggregates.py#L39
+# https://github.com/mozilla/bigquery-etl/blob/c48ab6649448cdf41191f6c24cb00fe46ca2323d/bigquery_etl/glam/clients_daily_scalar_aggregates.py#L95
+SUPPORTED_GLAM_METRIC_TYPES = GLEAN_DISTRIBUTION_TYPES | {
+    "boolean",
+    "counter",
+    "labeled_counter",
+    "quantity",
+    "timespan",
+}
+
+# ETL specific snakecase taken from:
+# https://github.com/mozilla/bigquery-etl/blob/master/bigquery_etl/util/common.py
+#
+# Search for all camelCase situations in reverse with arbitrary lookaheads.
+REV_WORD_BOUND_PAT = re.compile(
+    r"""
+    \b                                  # standard word boundary
+    |(?<=[a-z][A-Z])(?=\d*[A-Z])        # A7Aa -> A7|Aa boundary
+    |(?<=[a-z][A-Z])(?=\d*[a-z])        # a7Aa -> a7|Aa boundary
+    |(?<=[A-Z])(?=\d*[a-z])             # a7A -> a7|A boundary
+    """,
+    re.VERBOSE,
+)
+
+
+def etl_snake_case(line: str) -> str:
+    """Convert a string into a snake_cased string."""
+    # replace non-alphanumeric characters with spaces in the reversed line
+    subbed = re.sub(r"[^\w]|_", " ", line[::-1])
+    # apply the regex on the reversed string
+    words = REV_WORD_BOUND_PAT.split(subbed)
+    # filter spaces between words and snake_case and reverse again
+    return "_".join([w.lower() for w in words if w.strip()])[::-1]
+
+
+def get_glam_metadata_for_metric(app, metric, ping_name):
+    # GLAM data is per application and per ping (well,
+    # only the metrics ping right now), when it exists
+    metric_type = metric.definition["type"]
+    if not GLAM_PRODUCT_MAPPINGS.get(app.app_id):
+        return {"glam_unsupported_reason": "This application is not supported by GLAM."}
+    elif metric.bq_prefix in ["client_info", "ping_info"]:
+        return {"glam_unsupported_reason": "Internal Glean metrics are not supported by GLAM."}
+    elif metric_type not in SUPPORTED_GLAM_METRIC_TYPES:
+        return {
+            "glam_unsupported_reason": "Currently GLAM does not support "
+            f"`{metric_type}` metrics."
+        }
+    elif ping_name != "metrics":
+        return {
+            "glam_unsupported_reason": (
+                f"Metrics sent in the `{ping_name}` ping are not supported "
+                "by GLAM "
+                "([mozilla/glam#1652](https://github.com/mozilla/glam/issues/1652))."
+            )
+        }
+
+    (glam_product, glam_app_id) = GLAM_PRODUCT_MAPPINGS[app.app_id]
+    glam_metric_id = etl_snake_case(metric.identifier)
+    return {
+        "glam_url": (
+            "https://glam.telemetry.mozilla.org/"
+            + f"{glam_product}/probe/{glam_metric_id}/explore"
+            + f"?app_id={glam_app_id}"
+        )
+    }

--- a/scripts/glean.py
+++ b/scripts/glean.py
@@ -9,6 +9,13 @@ import requests
 logger = logging.getLogger(__name__)
 
 
+GLEAN_DISTRIBUTION_TYPES = {
+    "timing_distribution",
+    "memory_distribution",
+    "custom_distribution",
+}
+
+
 class _Cache:
     """
     Simple cache manager so we can avoid refetching the same dependency data

--- a/scripts/looker.py
+++ b/scripts/looker.py
@@ -1,0 +1,201 @@
+import json
+import urllib.parse
+
+import stringcase
+from bigquery import get_bigquery_column_name, get_bigquery_ping_table_name
+from glean import GLEAN_DISTRIBUTION_TYPES
+
+SUPPORTED_LOOKER_METRIC_TYPES = GLEAN_DISTRIBUTION_TYPES | {
+    "boolean",
+    "counter",
+    "datetime",
+    "jwe",
+    "labeled_counter",
+    "quantity",
+    "string",
+    "rate",
+    "timespan",
+    "uuid",
+}
+
+
+def _get_looker_ping_explore_url(looker_namespaces, app_name, ping_name, table_name, app_channel):
+    ping_name_snakecase = stringcase.snakecase(ping_name)
+    if (
+        looker_namespaces.get(app_name)
+        and looker_namespaces[app_name].get("glean_app")
+        and looker_namespaces[app_name]["explores"].get(ping_name_snakecase)
+    ):
+        channel_identifier = "mozdata." + table_name.replace("_", "%5E_")
+        return f"https://mozilla.cloud.looker.com/explore/{app_name}/{ping_name_snakecase}?" + (
+            f"f[{ping_name_snakecase}.channel]={channel_identifier}" if app_channel else ""
+        )
+    return None
+
+
+def _get_looker_event_count_explore_url(looker_namespaces, app_name, channel_name):
+    if (
+        looker_namespaces.get(app_name)
+        and looker_namespaces[app_name].get("glean_app")
+        and looker_namespaces[app_name]["explores"].get("events")
+    ):
+        base_url = (
+            f"https://mozilla.cloud.looker.com/explore/{app_name}/event_counts"
+            + "?fields=events.event_count,events.client_count"
+        )
+        return (
+            base_url + f"&f[events.normalized_channel]={channel_name}" if channel_name else base_url
+        )
+
+    return None
+
+
+def get_looker_explore_metadata_for_ping(looker_namespaces, app, ping):
+    return (
+        {
+            "name": "event_counts",
+            "url": _get_looker_event_count_explore_url(
+                looker_namespaces, app.app_name, app.app.get("app_channel")
+            ),
+        }
+        if ping.identifier == "events"
+        else {
+            "name": ping.identifier,
+            "url": _get_looker_ping_explore_url(
+                looker_namespaces,
+                app.app_name,
+                ping.identifier,
+                get_bigquery_ping_table_name(app.app["bq_dataset_family"], ping.identifier),
+                app.app.get("app_channel"),
+            ),
+        }
+    )
+
+
+def get_looker_explore_metadata_for_metric(
+    looker_namespaces, app, metric, ping_name, ping_has_client_id
+):
+    metric_type = metric.definition["type"]
+    metric_name_snakecase = stringcase.snakecase(metric.identifier)
+    ping_name_snakecase = stringcase.snakecase(ping_name)
+
+    base_looker_explore_name = "event_counts" if ping_name == "events" else ping_name
+    base_looker_explore_link = (
+        _get_looker_event_count_explore_url(
+            looker_namespaces, app.app_name, app.app.get("app_channel")
+        )
+        if ping_name == "events"
+        else _get_looker_ping_explore_url(
+            looker_namespaces,
+            app.app_name,
+            ping_name,
+            get_bigquery_ping_table_name(app.app["bq_dataset_family"], ping_name),
+            app.app.get("app_channel"),
+        )
+    )
+
+    # we deliberately don't show looker information for deprecated applications
+    if not app.app.get("deprecated") and base_looker_explore_link:
+        looker_metric_link = None
+        if metric_type == "event":
+            (metric_category, metric_name) = metric.identifier.split(".", 1)
+            looker_metric_link = (
+                base_looker_explore_link
+                + f"&f[events.event_name]=%22{metric_name}%22"
+                + f"&f[events.event_category]=%22{metric_category}%22"
+            )
+        # for counters, we can use measures directly
+        if metric_type == "counter":
+            looker_metric_link = (
+                base_looker_explore_link
+                + "&fields="
+                + ",".join(
+                    [
+                        f"{ping_name_snakecase}.submission_date",
+                        f"{ping_name_snakecase}.{metric_name_snakecase}",
+                    ]
+                )
+            )
+        elif metric_type == "labeled_counter":
+            counter_field_base = (
+                f"{ping_name_snakecase}"
+                + "__metrics__labeled_counter__"
+                + f"{metric_name_snakecase}"
+            )
+            looker_metric_link = (
+                base_looker_explore_link
+                + "&fields="
+                + ",".join(
+                    [
+                        f"{ping_name_snakecase}.submission_date",
+                        f"{counter_field_base}.label",
+                        f"{counter_field_base}.count",
+                    ]
+                )
+                + f"&pivots={counter_field_base}.label"
+            )
+        elif metric_type in SUPPORTED_LOOKER_METRIC_TYPES:
+            base_looker_dimension_name = "{}.{}".format(
+                ping_name_snakecase, get_bigquery_column_name(metric).replace(".", "__")
+            )
+
+            # For distribution types, we'll aggregate the sum of all distributions per
+            # day. In most cases, this isn't super meaningful, but provides a starting
+            # place for further analysis
+            if metric_type in GLEAN_DISTRIBUTION_TYPES:
+                looker_dimension_name = base_looker_dimension_name + "__sum"
+                custom_field_name = f"sum_of_{metric_name_snakecase}"
+                dynamic_fields = [
+                    dict(
+                        measure=custom_field_name,
+                        label=f"Sum of {metric.identifier}",
+                        based_on=looker_dimension_name,
+                        expression="",
+                        type="sum",
+                    )
+                ]
+                looker_metric_link = (
+                    base_looker_explore_link
+                    + "&fields="
+                    + ",".join(
+                        [
+                            f"{ping_name_snakecase}.submission_date",
+                            custom_field_name,
+                        ]
+                    )
+                    + "&dynamic_fields="
+                    + urllib.parse.quote_plus(json.dumps(dynamic_fields))
+                )
+            else:
+                # otherwise pivoting on the dimension is the best we can do (this works
+                # well for boolean measures)
+                looker_metric_link = (
+                    base_looker_explore_link
+                    + "&fields="
+                    + ",".join(
+                        [
+                            f"{ping_name_snakecase}.submission_date",
+                            base_looker_dimension_name,
+                            (
+                                f"{ping_name_snakecase}.clients"
+                                if ping_has_client_id
+                                else f"{ping_name_snakecase}.ping_count"
+                            ),
+                        ]
+                    )
+                    + f"&pivots={base_looker_dimension_name}"
+                )
+
+        if looker_metric_link:
+            return {
+                "base": {
+                    "name": base_looker_explore_name,
+                    "url": base_looker_explore_link,
+                },
+                "metric": {
+                    "name": metric.identifier,
+                    "url": f"{looker_metric_link}&toggle=vis",
+                },
+            }
+
+    return None


### PR DESCRIPTION
In particular, seperate out etl logic dealing with bigquery, looker,
and glam etl into their own files. This will hopefully make it easier
to understand, extend and write tests on in the future.

This change deliberately tries to keep the output as similar as possible
to what it was before, to make it easier to audit the output.
