### PR TITLE
Allow search only by tag/origin labels (fixes #880)

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -1,6 +1,5 @@
 <script>
   import { chunk } from "lodash";
-  import { Document } from "flexsearch";
 
   import { getItemURL } from "../state/urls";
   import { stripLinks } from "../formatters/markdown";
@@ -40,21 +39,6 @@
   let topElement;
   let scrollY;
   let totalItems;
-
-  const searchIndex = new Document({
-    tokenize: "forward",
-    index: ["id", "type", "tags", "origin", "description"],
-  });
-
-  items.forEach((item) => {
-    searchIndex.add({
-      id: item.name,
-      type: item.type,
-      tags: item.tags,
-      origin: item.origin,
-      description: item.description,
-    });
-  });
 
   function getItemTypeSingular(pluralized) {
     // cut off the trailing 's'

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -21,6 +21,8 @@
     getLibraryDescription,
   } from "../data/help";
 
+  import { fullTextSearch } from "../state/search";
+
   let DEFAULT_ITEMS_PER_PAGE = 20;
 
   export let appName;
@@ -59,36 +61,9 @@
     return pluralized.slice(0, -1);
   }
 
-  function fullTextSearch(query, searchItems) {
-    let filteredSearchItems = searchItems;
-    let searchQuery = query;
-
-    if (query.startsWith("tags:") || query.startsWith("origin:")) {
-      const labelType = query.split(":")[0]; // e.g. "tags" or "origin"
-      // separate label query from search query
-      const [label, searchValue] = query.split(":")[1].split(" ");
-
-      filteredSearchItems = searchItems.filter(
-        (item) => item[labelType] && item[labelType].includes(label)
-      );
-
-      // returns all items of that label if no extra search term is specified
-      if (!searchValue) return filteredSearchItems;
-      searchQuery = searchValue;
-    }
-
-    const results = [
-      ...new Set(
-        searchIndex
-          .search(searchQuery, { limit: 10000 })
-          .flatMap((match) => match.result)
-      ),
-    ];
-    return results
-      .map((result) => {
-        return filteredSearchItems.find((item) => item.name === result);
-      })
-      .filter((el) => el !== undefined);
+  function handleSearch(searchItems, text, expired) {
+    const searchResult = text ? fullTextSearch(text, searchItems) : searchItems;
+    return filterUncollectedItems(searchResult, expired);
   }
 
   function highlightSearch(text, query) {

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -1,5 +1,6 @@
 <script>
   import { chunk } from "lodash";
+  import { Document } from "flexsearch";
 
   import { getItemURL } from "../state/urls";
   import { stripLinks } from "../formatters/markdown";
@@ -40,14 +41,24 @@
   let scrollY;
   let totalItems;
 
+  const searchIndex = new Document({
+    tokenize: "forward",
+    index: ["id", "type", "tags", "origin", "description"],
+  });
+
+  items.forEach((item) => {
+    searchIndex.add({
+      id: item.name,
+      type: item.type,
+      tags: item.tags,
+      origin: item.origin,
+      description: item.description,
+    });
+  });
+
   function getItemTypeSingular(pluralized) {
     // cut off the trailing 's'
     return pluralized.slice(0, -1);
-  }
-
-  function handleSearch(searchItems, text, expired) {
-    const searchResult = text ? fullTextSearch(text, searchItems) : searchItems;
-    return filterUncollectedItems(searchResult, expired);
   }
 
   function highlightSearch(text, query) {

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -5,21 +5,17 @@ export const filterUncollectedItems = (items, showUncollected) =>
     (item) => showUncollected || (!isExpired(item) && !isRemoved(item))
   );
 
-const filterUnmatchedItems = (firstArray, secondArray) =>
+export const filterUnmatchedItems = (firstArray, secondArray) =>
   firstArray.filter((l) => secondArray.includes(l));
 
 export const filterItemsByLabels = (items, labels) => {
   let itemsFilteredByLabels = items;
 
-  // an item can have many tags, but only one origin
   const filteredItems = (label) => {
-    return label === "tags"
-      ? items.filter((item) =>
-          labels.tags.every((tag) => item.tags.includes(tag))
-        )
-      : items.filter(
-          (item) => item.origin && item.origin.includes(labels.origin[0])
-        );
+    return items.filter(
+      (item) =>
+        item[label] && labels[label].every((el) => item[label].includes(el))
+    );
   };
 
   Object.keys(labels).forEach((key) => {

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -1,4 +1,34 @@
 import { isExpired, isRemoved } from "./items";
 
-export const filterUncollectedItems = (items) =>
-  items.filter((item) => !isExpired(item) && !isRemoved(item));
+export const filterUncollectedItems = (items, showUncollected) =>
+  items.filter(
+    (item) => showUncollected || (!isExpired(item) && !isRemoved(item))
+  );
+
+const filterUnmatchedItems = (firstArray, secondArray) =>
+  firstArray.filter((l) => secondArray.includes(l));
+
+export const filterItemsByLabels = (items, labels) => {
+  let itemsFilteredByLabels = items;
+
+  // an item can have many tags, but only one origin
+  const filteredItems = (label) => {
+    return label === "tags"
+      ? items.filter((item) =>
+          labels.tags.every((tag) => item.tags.includes(tag))
+        )
+      : items.filter(
+          (item) => item.origin && item.origin.includes(labels.origin[0])
+        );
+  };
+
+  Object.keys(labels).forEach((key) => {
+    if (labels[key].length) {
+      itemsFilteredByLabels = filterUnmatchedItems(
+        filteredItems(key),
+        itemsFilteredByLabels
+      );
+    }
+  });
+  return itemsFilteredByLabels;
+};

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -11,7 +11,8 @@ export const filterUnmatchedItems = (firstArray, secondArray) =>
 export const filterItemsByLabels = (items, labels) => {
   let itemsFilteredByLabels = items;
 
-  const filteredItems = (label) => {
+  // filter items that match specified tags and origin
+  const getItemsByLabel = (label) => {
     return items.filter(
       (item) =>
         item[label] && labels[label].every((el) => item[label].includes(el))
@@ -21,7 +22,7 @@ export const filterItemsByLabels = (items, labels) => {
   Object.keys(labels).forEach((key) => {
     if (labels[key].length) {
       itemsFilteredByLabels = filterUnmatchedItems(
-        filteredItems(key),
+        getItemsByLabel(key),
         itemsFilteredByLabels
       );
     }

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -1,3 +1,4 @@
+import { intersection } from "lodash";
 import { isExpired, isRemoved } from "./items";
 
 export const filterUncollectedItems = (items, showUncollected) =>
@@ -5,13 +6,11 @@ export const filterUncollectedItems = (items, showUncollected) =>
     (item) => showUncollected || (!isExpired(item) && !isRemoved(item))
   );
 
-export const filterUnmatchedItems = (firstArray, secondArray) =>
-  firstArray.filter((l) => secondArray.includes(l));
-
 export const filterItemsByLabels = (items, labels) => {
   let itemsFilteredByLabels = items;
 
-  // filter items that match specified tags and origin
+  // filter items that match every value of a label type
+  // (e.g. an item can have multiple tags)
   const getItemsByLabel = (label) => {
     return items.filter(
       (item) =>
@@ -19,9 +18,11 @@ export const filterItemsByLabels = (items, labels) => {
     );
   };
 
+  // for each label type, get an array of items that match all labels of that type
+  // then, filter the result by getting the intersection of said arrays
   Object.keys(labels).forEach((key) => {
     if (labels[key].length) {
-      itemsFilteredByLabels = filterUnmatchedItems(
+      itemsFilteredByLabels = intersection(
         getItemsByLabel(key),
         itemsFilteredByLabels
       );

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -1,0 +1,59 @@
+import { Document } from "flexsearch";
+
+import { filterItemsByLabels } from "./filter";
+
+export const generateSearchIndex = (items) => {
+  const searchIndex = new Document({
+    tokenize: "forward",
+    index: ["id", "type", "tags", "origin", "description"],
+  });
+  items.forEach((item) => {
+    searchIndex.add({
+      id: item.name,
+      type: item.type,
+      tags: item.tags,
+      origin: item.origin,
+      description: item.description,
+    });
+  });
+  return searchIndex;
+};
+
+export const fullTextSearch = (query, searchItems) => {
+  const searchIndex = generateSearchIndex(searchItems);
+  let searchQueryWithoutLabels = "";
+  let itemsFilteredByLabels = searchItems;
+
+  const searchWords = query.split(" ");
+  const labels = { tags: [], origin: [] };
+
+  searchWords.forEach((word) => {
+    if (word.startsWith("tags:") || word.startsWith("origin:")) {
+      const labelType = word.split(":")[0];
+      labels[labelType] = [...labels[labelType], word.split(":")[1]];
+    } else {
+      // join the rest of the tokens
+      searchQueryWithoutLabels = word
+        ? `${searchQueryWithoutLabels} ${word}`
+        : searchQueryWithoutLabels;
+    }
+  });
+
+  itemsFilteredByLabels = filterItemsByLabels(searchItems, labels);
+
+  if (!query || !searchQueryWithoutLabels) return itemsFilteredByLabels;
+
+  const results = [
+    ...new Set(
+      searchIndex
+        .search(searchQueryWithoutLabels, { limit: 10000 })
+        .flatMap((match) => match.result)
+    ),
+  ];
+
+  return results
+    .map((result) => {
+      return itemsFilteredByLabels.find((item) => item.name === result);
+    })
+    .filter((el) => el !== undefined);
+};

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -2,11 +2,12 @@ import { Document } from "flexsearch";
 
 import { filterItemsByLabels } from "./filter";
 
-export const generateSearchIndex = (items) => {
+const generateSearchIndex = (items) => {
   const searchIndex = new Document({
     tokenize: "forward",
     index: ["id", "type", "tags", "origin", "description"],
   });
+
   items.forEach((item) => {
     searchIndex.add({
       id: item.name,
@@ -16,23 +17,24 @@ export const generateSearchIndex = (items) => {
       description: item.description,
     });
   });
+
   return searchIndex;
 };
 
 export const fullTextSearch = (query, searchItems) => {
-  const searchIndex = generateSearchIndex(searchItems);
   let searchQueryWithoutLabels = "";
   let itemsFilteredByLabels = searchItems;
 
   const searchWords = query.split(" ");
   const labels = { tags: [], origin: [] };
+  const searchIndex = generateSearchIndex(searchItems);
 
   searchWords.forEach((word) => {
     if (word.startsWith("tags:") || word.startsWith("origin:")) {
       const labelType = word.split(":")[0];
       labels[labelType] = [...labels[labelType], word.split(":")[1]];
     } else {
-      // join the rest of the tokens
+      // join the rest of the search tokens
       searchQueryWithoutLabels = word
         ? `${searchQueryWithoutLabels} ${word}`
         : searchQueryWithoutLabels;
@@ -46,6 +48,7 @@ export const fullTextSearch = (query, searchItems) => {
   const results = [
     ...new Set(
       searchIndex
+        // manually set the limit here to get all results (FlexSearch only returns 100 entries: https://github.com/nextapps-de/flexsearch#limit--offset)
         .search(searchQueryWithoutLabels, { limit: 10000 })
         .flatMap((match) => match.result)
     ),

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -1,4 +1,8 @@
-import { filterUncollectedItems } from "../src/state/filter";
+import {
+  filterUncollectedItems,
+  filterUnmatchedItems,
+  filterItemsByLabels,
+} from "../src/state/filter";
 
 const today = new Date();
 const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
@@ -27,6 +31,27 @@ const items = [
   },
   { name: "metric.expired", expires: getDateStr(yesterday), in_source: true },
   { name: "metric.removed", expires: getDateStr(tomorrow), in_source: false },
+  {
+    name: "metric.foo",
+    expires: getDateStr(tomorrow),
+    origin: "sync",
+    tags: ["Foo", "Bar"],
+    in_source: false,
+  },
+  {
+    name: "metric.bar",
+    expires: getDateStr(tomorrow),
+    tags: ["Foo"],
+    origin: "sync",
+    in_source: false,
+  },
+  {
+    name: "metric.baz",
+    expires: getDateStr(tomorrow),
+    tags: ["Foo", "Bar", "Baz"],
+    origin: "sync",
+    in_source: false,
+  },
 ];
 
 describe("expiry", () => {
@@ -34,5 +59,21 @@ describe("expiry", () => {
     expect(getNames(filterUncollectedItems(items, false))).toEqual([
       "metric.bestsitez",
       "metric.camel",
+    ]));
+});
+
+describe("filter unmatched items", () => {
+  it("returns the inner join of 2 arrays", () =>
+    expect(filterUnmatchedItems([1, 2, 3, 4, 5], [3, 4, 5, 6, 7])).toEqual([
+      3, 4, 5,
+    ]));
+});
+
+describe("filter items by labels", () => {
+  const labels = { tags: ["Foo", "Bar"], origin: ["sync"] };
+  it("returns items of origin 'sync', with tags 'Foo' and 'Bar'", () =>
+    expect(getNames(filterItemsByLabels(items, labels))).toEqual([
+      "metric.foo",
+      "metric.baz",
     ]));
 });

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -1,6 +1,5 @@
 import {
   filterUncollectedItems,
-  filterUnmatchedItems,
   filterItemsByLabels,
 } from "../src/state/filter";
 
@@ -59,13 +58,6 @@ describe("expiry", () => {
     expect(getNames(filterUncollectedItems(items, false))).toEqual([
       "metric.bestsitez",
       "metric.camel",
-    ]));
-});
-
-describe("filter unmatched items", () => {
-  it("returns the inner join of 2 arrays", () =>
-    expect(filterUnmatchedItems([1, 2, 3, 4, 5], [3, 4, 5, 6, 7])).toEqual([
-      3, 4, 5,
     ]));
 });
 

--- a/tests/state.search.test.js
+++ b/tests/state.search.test.js
@@ -1,0 +1,63 @@
+import { fullTextSearch } from "../src/state/search";
+
+const getNames = (items) => items.map((i) => i.name);
+
+const items = [
+  {
+    name: "metric.one",
+    tags: ["TopSites"],
+    type: "string",
+    description: "abc def",
+  },
+  {
+    name: "metric.two",
+    origin: "glean-core",
+    type: "string",
+    description: "ghi jkl",
+  },
+  {
+    name: "metric.three",
+    origin: "sync",
+    tags: ["Foo", "Bar"],
+    type: "event",
+    description: "mno pqr test",
+  },
+  {
+    name: "metric.four",
+    tags: ["Foo"],
+    origin: "sync",
+    type: "string",
+    description: "tuv wxy",
+  },
+  {
+    name: "metric.five",
+    tags: ["Foo", "Bar", "Baz"],
+    origin: "sync",
+    type: "event",
+    description: "z abc",
+  },
+];
+
+describe("search", () => {
+  it("returns items of Foo tags and sync origin", () =>
+    expect(getNames(fullTextSearch("tags:Foo origin:sync", items))).toEqual([
+      "metric.three",
+      "metric.four",
+      "metric.five",
+    ]));
+  it("returns items of Foo tags, sync origin, with search word 'three'", () =>
+    expect(
+      getNames(fullTextSearch("three tags:Foo origin:sync", items))
+    ).toEqual(["metric.three"]));
+  it("returns the items that match the description abc", () =>
+    expect(getNames(fullTextSearch("abc", items))).toEqual([
+      "metric.one",
+      "metric.five",
+    ]));
+  it("returns only type string items", () =>
+    expect(getNames(fullTextSearch("string", items))).toEqual([
+      "metric.one",
+      "metric.two",
+      "metric.four",
+    ]));
+});

--- a/tests/state.search.test.js
+++ b/tests/state.search.test.js
@@ -36,6 +36,13 @@ const items = [
     type: "event",
     description: "z abc",
   },
+  {
+    name: "metric.six",
+    tags: ["A:Tag"],
+    origin: "engine-gecko",
+    type: "boolean",
+    description: "def ghi",
+  },
 ];
 
 describe("search", () => {
@@ -45,19 +52,27 @@ describe("search", () => {
       "metric.four",
       "metric.five",
     ]));
+
   it("returns items of Foo tags, sync origin, with search word 'three'", () =>
     expect(
       getNames(fullTextSearch("three tags:Foo origin:sync", items))
     ).toEqual(["metric.three"]));
-  it("returns the items that match the description abc", () =>
+
+  it("returns the items that match the description `abc`", () =>
     expect(getNames(fullTextSearch("abc", items))).toEqual([
       "metric.one",
       "metric.five",
     ]));
+
   it("returns only type string items", () =>
     expect(getNames(fullTextSearch("string", items))).toEqual([
       "metric.one",
       "metric.two",
       "metric.four",
+    ]));
+
+  it("works correctly with tags that has a `:` in its name", () =>
+    expect(getNames(fullTextSearch("tags:A:Tag", items))).toEqual([
+      "metric.six",
     ]));
 });


### PR DESCRIPTION
Adds an option to let users search by just the labels.

Examples:

- add `tags:` + `tagName` to filter text to search just by tags: https://deploy-preview-935--glean-dictionary-dev.netlify.app/apps/fenix?itemType=metrics&page=1&search=tags%3ALogins%20save
- add `origin:` + `originName` to search by origins: https://deploy-preview-935--glean-dictionary-dev.netlify.app/apps/fenix?itemType=metrics&page=1&search=origin%3Async

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
