### PR TITLE
Improve handling of uncollected metrics

### DIFF
--- a/src/__snapshots__/storyshots.test.js.snap
+++ b/src/__snapshots__/storyshots.test.js.snap
@@ -571,31 +571,31 @@ exports[`Storyshots ItemList Default 1`] = `
   class="storybook-snapshot-container"
 >
   <div
-    class="svelte-iia7x6"
+    class="svelte-lsmn69"
   >
     <span
-      class="expire-checkbox svelte-iia7x6"
+      class="expire-checkbox svelte-lsmn69"
     >
       <label
-        class="svelte-iia7x6"
+        class="svelte-lsmn69"
       >
         <input
-          class="svelte-iia7x6"
+          class="svelte-lsmn69"
           type="checkbox"
         />
         
-          Show expired and removed metrics
+        Show expired and removed metrics
       </label>
        
       <label
-        class="svelte-iia7x6"
+        class="svelte-lsmn69"
       >
         <input
-          class="svelte-iia7x6"
+          class="svelte-lsmn69"
           type="checkbox"
         />
         
-          Paginate
+        Paginate
       </label>
     </span>
      
@@ -611,34 +611,34 @@ exports[`Storyshots ItemList Default 1`] = `
     </div>
      
     <div
-      class="item-browser svelte-iia7x6"
+      class="item-browser svelte-lsmn69"
     >
       <table
-        class="mzp-u-data-table svelte-iia7x6"
+        class="mzp-u-data-table svelte-lsmn69"
       >
         <col
-          class="svelte-iia7x6"
+          class="svelte-lsmn69"
           width="35%"
         />
          
         <col
-          class="svelte-iia7x6"
+          class="svelte-lsmn69"
           width="20%"
         />
          
         <col
-          class="svelte-iia7x6"
+          class="svelte-lsmn69"
           width="45%"
         />
          
         <thead
-          class="svelte-iia7x6"
+          class="svelte-lsmn69"
         >
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <th
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               scope="col"
               style="text-align: center;"
             >
@@ -646,7 +646,7 @@ exports[`Storyshots ItemList Default 1`] = `
             </th>
              
             <th
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               scope="col"
               style="text-align: center;"
             >
@@ -654,7 +654,7 @@ exports[`Storyshots ItemList Default 1`] = `
             </th>
              
             <th
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               scope="col"
               style="text-align: center;"
             >
@@ -664,19 +664,19 @@ exports[`Storyshots ItemList Default 1`] = `
         </thead>
          
         <tbody
-          class="svelte-iia7x6"
+          class="svelte-lsmn69"
         >
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 0"
                 >
                   test metric 0
@@ -689,14 +689,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -704,10 +704,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 0"
               >
                 This is test metric 0
@@ -718,16 +718,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 1"
                 >
                   test metric 1
@@ -740,14 +740,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -755,10 +755,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 1"
               >
                 This is test metric 1
@@ -769,16 +769,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 2"
                 >
                   test metric 2
@@ -791,14 +791,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -806,10 +806,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 2"
               >
                 This is test metric 2
@@ -820,16 +820,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 3"
                 >
                   test metric 3
@@ -842,14 +842,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -857,10 +857,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 3"
               >
                 This is test metric 3
@@ -871,16 +871,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 4"
                 >
                   test metric 4
@@ -893,14 +893,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -908,10 +908,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 4"
               >
                 This is test metric 4
@@ -922,16 +922,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 5"
                 >
                   test metric 5
@@ -944,14 +944,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -959,10 +959,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 5"
               >
                 This is test metric 5
@@ -973,16 +973,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 6"
                 >
                   test metric 6
@@ -995,14 +995,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1010,10 +1010,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 6"
               >
                 This is test metric 6
@@ -1024,16 +1024,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 7"
                 >
                   test metric 7
@@ -1046,14 +1046,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1061,10 +1061,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 7"
               >
                 This is test metric 7
@@ -1075,16 +1075,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 8"
                 >
                   test metric 8
@@ -1097,14 +1097,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1112,10 +1112,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 8"
               >
                 This is test metric 8
@@ -1126,16 +1126,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 9"
                 >
                   test metric 9
@@ -1148,14 +1148,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1163,10 +1163,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 9"
               >
                 This is test metric 9
@@ -1177,16 +1177,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 10"
                 >
                   test metric 10
@@ -1199,14 +1199,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1214,10 +1214,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 10"
               >
                 This is test metric 10
@@ -1228,16 +1228,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 11"
                 >
                   test metric 11
@@ -1250,14 +1250,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1265,10 +1265,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 11"
               >
                 This is test metric 11
@@ -1279,16 +1279,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 12"
                 >
                   test metric 12
@@ -1301,14 +1301,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1316,10 +1316,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 12"
               >
                 This is test metric 12
@@ -1330,16 +1330,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 13"
                 >
                   test metric 13
@@ -1352,14 +1352,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1367,10 +1367,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 13"
               >
                 This is test metric 13
@@ -1381,16 +1381,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 14"
                 >
                   test metric 14
@@ -1403,14 +1403,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1418,10 +1418,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 14"
               >
                 This is test metric 14
@@ -1432,16 +1432,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 15"
                 >
                   test metric 15
@@ -1454,14 +1454,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1469,10 +1469,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 15"
               >
                 This is test metric 15
@@ -1483,16 +1483,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 16"
                 >
                   test metric 16
@@ -1505,14 +1505,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1520,10 +1520,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 16"
               >
                 This is test metric 16
@@ -1534,16 +1534,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 17"
                 >
                   test metric 17
@@ -1556,14 +1556,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1571,10 +1571,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 17"
               >
                 This is test metric 17
@@ -1585,16 +1585,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 18"
                 >
                   test metric 18
@@ -1607,14 +1607,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1622,10 +1622,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 18"
               >
                 This is test metric 18
@@ -1636,16 +1636,16 @@ exports[`Storyshots ItemList Default 1`] = `
              
           </tr>
           <tr
-            class="svelte-iia7x6"
+            class="svelte-lsmn69"
           >
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <a
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                   href="/apps/app-name/metrics/test metric 19"
                 >
                   test metric 19
@@ -1658,14 +1658,14 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="svelte-iia7x6"
+              class="svelte-lsmn69"
               style="text-align: center;"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
               >
                 <code
-                  class="svelte-iia7x6"
+                  class="svelte-lsmn69"
                 >
                   metric_type
                 </code>
@@ -1673,10 +1673,10 @@ exports[`Storyshots ItemList Default 1`] = `
             </td>
              
             <td
-              class="description svelte-iia7x6"
+              class="description svelte-lsmn69"
             >
               <div
-                class="item-property svelte-iia7x6"
+                class="item-property svelte-lsmn69"
                 title="This is test metric 19"
               >
                 This is test metric 19
@@ -1689,6 +1689,7 @@ exports[`Storyshots ItemList Default 1`] = `
         </tbody>
       </table>
     </div>
+     
      
     <div
       class="pagination-position svelte-dgls7k"

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -37,6 +37,7 @@
   let showUncollected;
   let topElement;
   let scrollY;
+  let totalItems;
 
   const searchIndex = new Document({
     tokenize: "forward",
@@ -67,11 +68,6 @@
     });
   }
 
-  function handleSearch(searchItems, text, expired) {
-    const searchResult = text ? fullTextSearch(text, searchItems) : searchItems;
-    return filterUncollectedItems(searchResult, expired);
-  }
-
   function highlightSearch(text, query) {
     return query.length
       ? text.replace(
@@ -82,17 +78,22 @@
   }
 
   $: {
-    showUncollected =
-      $pageState.showUncollected === undefined
-        ? true
-        : $pageState.showUncollected;
+    showUncollected = $pageState.showUncollected;
     search = $pageState.search || "";
   }
 
   // update pagedItems when either pagination changes or search text changes
   // (above)
   $: {
-    filteredItems = handleSearch(items, search, showUncollected);
+    // after filtering for text, but before filtering for uncollected
+    // (expired or removed)
+    filteredItems = search ? fullTextSearch(search, items) : items;
+    totalItems = filteredItems.length;
+
+    // now filter for uncollected items (if applicable)
+    filteredItems = showUncollected
+      ? filteredItems
+      : filterUncollectedItems(filteredItems);
 
     // update pagination
     const currentPage = $pageState.page || 1;
@@ -121,34 +122,51 @@
 <svelte:window bind:scrollY />
 
 <div bind:this={topElement}>
-  {#if !items.length}
-    <p>
-      No {itemType} found matching specified criteria.
-    </p>
+  {#if itemType === "metrics"}
+    <span class="expire-checkbox">
+      <label>
+        <input
+          type="checkbox"
+          bind:checked={showUncollected}
+          on:change={() => {
+            // the binding changes *after* this callback is called, so use
+            // the inverse value
+            updateURLState({ showUncollected: !showUncollected });
+          }}
+        />
+        Show expired and removed metrics
+      </label>
+      <label>
+        <input type="checkbox" bind:checked={paginated} />
+        Paginate
+      </label>
+    </span>
+  {/if}
+  {#if showFilter}
+    <FilterInput placeHolder="Search {itemType}" />
+  {/if}
+  {#if !filteredItems.length}
+    <div class="items-not-found">
+      <h3>
+        No {totalItems > 0 ? "active" : ""}
+        {itemType} found matching specified criteria
+      </h3>
+      {#if totalItems > 0}
+        <p>
+          {totalItems} expired or removed {itemType} found.
+        </p>
+        <button
+          class="mzp-c-button mzp-t-secondary mzp-t-md"
+          on:click={() => {
+            showUncollected = true;
+            updateURLState({ showUncollected });
+          }}>Show</button
+        >
+      {:else}
+        <p>Try entering less specific or alternate search terms.</p>
+      {/if}
+    </div>
   {:else}
-    {#if itemType === "metrics"}
-      <span class="expire-checkbox">
-        <label>
-          <input
-            type="checkbox"
-            bind:checked={showUncollected}
-            on:change={() => {
-              // the binding changes *after* this callback is called, so use
-              // the inverse value
-              updateURLState({ showUncollected: !showUncollected });
-            }}
-          />
-          Show expired and removed metrics
-        </label>
-        <label>
-          <input type="checkbox" bind:checked={paginated} />
-          Paginate
-        </label>
-      </span>
-    {/if}
-    {#if showFilter}
-      <FilterInput placeHolder="Search {itemType}" />
-    {/if}
     <div class="item-browser">
       <table class="mzp-u-data-table">
         <!-- We have to do inline styling here to override Protocol CSS rules -->
@@ -259,6 +277,14 @@
   {/if}
 
   {#if filteredItems.length && paginated}
+    {#if totalItems - filteredItems.length > 0}
+      <div class="items-not-found">
+        <p>
+          {totalItems - filteredItems.length} additional expired or removed {itemType}
+          found.
+        </p>
+      </div>
+    {/if}
     <Pagination
       totalItems={filteredItems.length}
       itemsPerPage={DEFAULT_ITEMS_PER_PAGE}
@@ -267,6 +293,8 @@
 </div>
 
 <style>
+  @import "@mozilla-protocol/core/protocol/css/components/_button.scss";
+
   .item-browser {
     a {
       text-decoration: none;
@@ -277,6 +305,10 @@
     height: 50px;
     overflow-y: auto;
     margin: -0.25rem;
+  }
+  .items-not-found {
+    padding-top: 40px;
+    text-align: center;
   }
 
   table {

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -163,7 +163,7 @@
           }}>Show</button
         >
       {:else}
-        <p>Try entering less specific or alternate search terms.</p>
+        <p>Try entering less specific or alternative search terms.</p>
       {/if}
     </div>
   {:else}

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -1,6 +1,4 @@
 import { isExpired, isRemoved } from "./items";
 
-export const filterUncollectedItems = (items, showUncollected) =>
-  items.filter(
-    (item) => showUncollected || (!isExpired(item) && !isRemoved(item))
-  );
+export const filterUncollectedItems = (items) =>
+  items.filter((item) => !isExpired(item) && !isRemoved(item));


### PR DESCRIPTION
* *Don't* show them by default
* However, when they do exist and would otherwise have matched a search term, provide some helpful text explaining what's going on and a button to reveal them
