### PR TITLE
Fix Playwright 'failed to launch browsers' error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: cp -r /tmp/workspace/data/* public/data/
+      # Install Playwright browsers
+      - run: npx playwright install
       - run: npm test
   backend-build-and-test:
     executor: python/default

--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ following command:
 npm run test:jest -- -u
 ```
 
+## End-to-End Testing
+
+We use [Playwright](https://playwright.dev/) for our end-to-end tests.
+
+Before testing, download the supported browsers needed for Playwright to execute
+successfully by running:
+
+```bash
+npx playwright install
+```
+
+To run the end-to-end tests along with other tests:
+
+```bash
+npm run test
+```
+
+To run only the Playwright tests:
+
+```bash
+npx playwright test
+```
+
 ## Deployment
 
 The production version of the Glean Dictionary

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "storybook": "start-storybook --static-dir ./public -p 6006",
     "test": "npm-run-all format:check lint test:jest test:playwright",
     "test:jest": "jest tests src --no-cache",
-    "test:playwright": "npx playwright test",
+    "test:playwright": "npx playwright install && npx playwright test",
     "build-glean-metadata": "node scripts/build-glean-metadata.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "storybook": "start-storybook --static-dir ./public -p 6006",
     "test": "npm-run-all format:check lint test:jest test:playwright",
     "test:jest": "jest tests src --no-cache",
-    "test:playwright": "npx playwright install && npx playwright test",
+    "test:playwright": "npx playwright test",
     "build-glean-metadata": "node scripts/build-glean-metadata.js"
   },
   "devDependencies": {


### PR DESCRIPTION
The Playwright CI test failed in my last PR: https://app.circleci.com/pipelines/github/mozilla/glean-dictionary/2768/workflows/727abea5-be8a-46af-b145-63f799b235de/jobs/5342

I updated the script to install Playwright per the recommendation in the error message.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
