### PR TITLE
Show the "deletion-request" ping last under access

### DIFF
--- a/scripts/build-glean-metadata.py
+++ b/scripts/build-glean-metadata.py
@@ -297,8 +297,9 @@ for (app_name, app_group) in app_groups.items():
                 )
 
                 # sort "send in pings" alphanumerically, except that `metrics`
-                # should always be first if present
-                ping_priority = {"metrics": 0}
+                # should always be first if present and `deletion-request`
+                # should be last
+                ping_priority = {"metrics": 0, "deletion-request": 2}
                 app_metrics[metric.identifier]["send_in_pings"].sort()
                 app_metrics[metric.identifier]["send_in_pings"].sort(
                     key=lambda ping: ping_priority.get(ping, 1)


### PR DESCRIPTION
This is specially relevant for Mozilla VPN, where there are only
two pings: main and deletion-request (and notably, no metrics ping
which would come first). 99% of the time it's the former that people
are interested in.
