### PR TITLE
Protocol/SCSS refactoring

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -14,11 +14,8 @@ module.exports = {
       ...svelteLoader.options,
       preprocess: sveltePreprocess({
         postcss: true,
-        defaults: {
-          style: "scss",
-        },
         scss: {
-          prependData: `@import '@mozilla-protocol/core/protocol/css/protocol.scss';`,
+          prependData: `@import 'src/protocol-tokens.scss';`,
         },
         postcss: {
           plugins: [autoPrefixer],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -71,11 +71,8 @@ export default {
       // a separate file - better for performance
       preprocess: sveltePreprocess({
         postcss: true,
-        defaults: {
-          style: "scss",
-        },
         scss: {
-          prependData: `@import 'node_modules/@mozilla-protocol/core/protocol/css/protocol.scss';`,
+          prependData: `@import 'src/protocol-tokens.scss';`,
         },
       }),
     }),

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -119,7 +119,7 @@
   <Footer />
 </div>
 
-<style>
+<style lang="scss">
   .app {
     min-height: 100vh;
     display: grid;

--- a/src/GlobalStyles.svelte
+++ b/src/GlobalStyles.svelte
@@ -1,4 +1,12 @@
-<style global>
-  @import "@mozilla-protocol/core/protocol/css/protocol.scss";
+<style lang="scss" global>
+  // a few default parts of protocol we want defined on every page
+  $image-path: "../img" !default;
+  $font-path: "../fonts" !default;
+
+  @import "@mozilla-protocol/core/protocol/css/includes/fonts/inter";
+  @import "@mozilla-protocol/core/protocol/css/includes/fonts/zilla-slab";
+  @import "@mozilla-protocol/core/protocol/css/base/elements";
+
+  // we also want tippy.js's CSS
   @import "tippy.js/dist/tippy.css";
 </style>

--- a/src/components/AppAlert.svelte
+++ b/src/components/AppAlert.svelte
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<style>
+<style lang="scss">
   .mzp-c-notification-bar {
     display: flex;
     align-items: center;

--- a/src/components/Breadcrumb.svelte
+++ b/src/components/Breadcrumb.svelte
@@ -35,7 +35,7 @@
   </ol>
 </div>
 
-<style>
+<style lang="scss">
   .breadcrumb {
     display: flex;
     margin-left: $spacing-xl;

--- a/src/components/FilterInput.svelte
+++ b/src/components/FilterInput.svelte
@@ -18,7 +18,7 @@
   />
 </div>
 
-<style>
+<style lang="scss">
   div {
     margin-top: $spacing-xs;
     margin-bottom: $spacing-xs;

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -58,3 +58,7 @@
     </nav>
   </div>
 </footer>
+
+<style lang="scss">
+  @import "@mozilla-protocol/core/protocol/css/components/footer";
+</style>

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -286,7 +286,7 @@
 </div>
 
 <style lang="scss">
-  @import "@mozilla-protocol/core/protocol/css/components/_button.scss";
+  @import "@mozilla-protocol/core/protocol/css/components/button";
 
   .item-browser {
     a {

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -285,7 +285,7 @@
   {/if}
 </div>
 
-<style>
+<style lang="scss">
   @import "@mozilla-protocol/core/protocol/css/components/_button.scss";
 
   .item-browser {

--- a/src/components/MetadataTable.svelte
+++ b/src/components/MetadataTable.svelte
@@ -59,7 +59,7 @@
   <slot />
 </table>
 
-<style>
+<style lang="scss">
   @import "../main.scss";
   @include metadata-table;
 </style>

--- a/src/components/PageHeader.svelte
+++ b/src/components/PageHeader.svelte
@@ -12,7 +12,7 @@
   </div>
 {/if}
 
-<style>
+<style lang="scss">
   h1 {
     @include text-title-sm;
   }

--- a/src/components/Pagination.svelte
+++ b/src/components/Pagination.svelte
@@ -102,7 +102,7 @@
   </div>
 {/if}
 
-<style>
+<style lang="scss">
   .pagination-position {
     margin-top: $spacing-md;
   }

--- a/src/components/SchemaNode.svelte
+++ b/src/components/SchemaNode.svelte
@@ -30,7 +30,7 @@
   {/each}
 {/if}
 
-<style>
+<style lang="scss">
   p {
     margin: 0;
   }

--- a/src/components/SchemaViewer.svelte
+++ b/src/components/SchemaViewer.svelte
@@ -58,7 +58,7 @@
   </div>
 </div>
 
-<style>
+<style lang="scss">
   .schema-viewer {
     margin-top: 2rem;
     .schema-browser {

--- a/src/components/SubHeading.svelte
+++ b/src/components/SubHeading.svelte
@@ -12,7 +12,7 @@
   {/if}
 </h2>
 
-<style>
+<style lang="scss">
   h2 {
     @include text-title-xs;
   }

--- a/src/components/icons/InfoIcon.svelte
+++ b/src/components/icons/InfoIcon.svelte
@@ -11,7 +11,7 @@
   />
 </svg>
 
-<style>
+<style lang="scss">
   svg {
     display: inline-block;
     width: 15px;

--- a/src/components/icons/MozillaLogo.svelte
+++ b/src/components/icons/MozillaLogo.svelte
@@ -20,7 +20,7 @@
   /></svg
 >
 
-<style>
+<style lang="scss">
   svg {
     display: block;
   }

--- a/src/components/tabs/Tab.svelte
+++ b/src/components/tabs/Tab.svelte
@@ -17,7 +17,7 @@
   <slot />
 </div>
 
-<style>
+<style lang="scss">
   .title {
     @include text-title-3xs;
     border-top-width: 0px;

--- a/src/components/tabs/TabContent.svelte
+++ b/src/components/tabs/TabContent.svelte
@@ -11,7 +11,7 @@
   </div>
 {/if}
 
-<style>
+<style lang="scss">
   .box {
     padding: 2rem;
     border: 1px solid $color-light-gray-60;

--- a/src/components/tabs/TabGroup.svelte
+++ b/src/components/tabs/TabGroup.svelte
@@ -25,7 +25,7 @@
   <slot />
 </div>
 
-<style>
+<style lang="scss">
   .tab-content {
     margin-top: $spacing-lg;
   }

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -119,7 +119,7 @@
   <NotFound pageName={params.app} itemType="application" />
 {/await}
 
-<style>
+<style lang="scss">
   @import "../main.scss";
   h2 {
     @include text-title-xs;

--- a/src/pages/AppIdDetail.svelte
+++ b/src/pages/AppIdDetail.svelte
@@ -49,7 +49,7 @@
   />
 {/await}
 
-<style>
+<style lang="scss">
   @import "../main.scss";
   h2 {
     @include text-title-xs;

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -179,7 +179,7 @@
 
 <style lang="scss">
   @import "@mozilla-protocol/core/protocol/css/components/card";
-  @import "@mozilla-protocol/core/protocol/css/components/_emphasis-box.scss";
+  @import "@mozilla-protocol/core/protocol/css/components/emphasis-box";
   .app-filter {
     margin: $spacing-md $spacing-xl;
     #deprecation-checkbox {

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -177,7 +177,8 @@
   </div>
 {/if}
 
-<style>
+<style lang="scss">
+  @import "@mozilla-protocol/core/protocol/css/components/card";
   @import "@mozilla-protocol/core/protocol/css/components/_emphasis-box.scss";
   .app-filter {
     margin: $spacing-md $spacing-xl;

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -296,7 +296,7 @@
   <NotFound pageName={params.metric} itemType="metric" />
 {/await}
 
-<style>
+<style lang="scss">
   @import "../main.scss";
   @include metadata-table;
   h2 {

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -150,7 +150,7 @@
   <NotFound pageName={params.ping} itemType="ping" />
 {/await}
 
-<style>
+<style lang="scss">
   @import "../main.scss";
 
   @include metadata-table;

--- a/src/pages/TableDetail.svelte
+++ b/src/pages/TableDetail.svelte
@@ -81,7 +81,7 @@
   <NotFound pageName={params.appId} itemType="table" />
 {/await}
 
-<style>
+<style lang="scss">
   @import "../main.scss";
   @include metadata-table;
 </style>

--- a/src/protocol-tokens.scss
+++ b/src/protocol-tokens.scss
@@ -1,0 +1,6 @@
+$image-path: "../img" !default;
+$font-path: "../fonts" !default;
+
+// Base utilities
+@import "@mozilla-protocol/core/protocol/css/base/utilities/backgrounds";
+@import "@mozilla-protocol/core/protocol/css/base/utilities/titles";

--- a/stories/AppAlert.svelte
+++ b/stories/AppAlert.svelte
@@ -14,7 +14,7 @@
 <p>Success Alert</p>
 <AppAlert status="success" message={alertMessage} />
 
-<style>
+<style lang="scss">
   p {
     @include text-title-xs;
   }

--- a/stories/Pagination.svelte
+++ b/stories/Pagination.svelte
@@ -94,7 +94,7 @@
   </div>
 {/if}
 
-<style>
+<style lang="scss">
   .pagination-position {
     margin-top: 3rem;
   }


### PR DESCRIPTION
* Move away from making scss the default, instead specify it manually
  ("defaults" are now discouraged: https://github.com/sveltejs/svelte-preprocess/issues/362)
* Import only the parts of protocol we actually need for each component,
  this speeds up the build by a fair chunk (50.25 -> 18.85 seconds on
  my MacBook) and helps pave the way to #682.
