### PR TITLE
Slightly reduce the size of generated json by omitting spaces

### DIFF
--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import requests
@@ -11,6 +10,7 @@ from .glam import SUPPORTED_GLAM_METRIC_TYPES, get_glam_metadata_for_metric
 from .glean import GleanApp
 from .looker import get_looker_explore_metadata_for_metric, get_looker_explore_metadata_for_ping
 from .search import create_metrics_search_js
+from .utils import dump_json
 
 # Various additional sources of metadata
 ANNOTATIONS_URL = os.getenv(
@@ -28,12 +28,6 @@ FIREFOX_PRODUCT_DETAIL_URL = os.getenv(
 METRIC_CHANNEL_PRIORITY = {"nightly": 1, "beta": 2, "release": 3, "esr": 4}
 # Priority for sorting app ids in the UI (of anticipated relevance to the suer)
 USER_CHANNEL_PRIORITY = {"release": 1, "beta": 2, "nightly": 3, "esr": 4}
-
-
-def _serialize_sets(obj):
-    if isinstance(obj, set):
-        return list(obj)
-    return obj
 
 
 def _normalize_metrics(name):
@@ -155,7 +149,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
         app_group["app_ids"].sort(key=lambda app_id: app_id["deprecated"])
 
     # Write out a list of app groups (for the landing page)
-    open(os.path.join(output_dir, "apps.json"), "w").write(json.dumps(list(app_groups.values())))
+    open(os.path.join(output_dir, "apps.json"), "w").write(dump_json(list(app_groups.values())))
 
     # Write out some metadata for each app group (for the app detail page)
     for (app_name, app_group) in app_groups.items():
@@ -192,7 +186,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
 
             # information about this app_id
             open(os.path.join(app_id_dir, f"{_get_resource_path(app_id)}.json"), "w").write(
-                json.dumps(app.app)
+                dump_json(app.app)
             )
 
             pings_with_client_id = set()
@@ -254,7 +248,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                 app_variant_table_dir = os.path.join(app_table_dir, _get_resource_path(app.app_id))
                 os.makedirs(app_variant_table_dir, exist_ok=True)
                 open(os.path.join(app_variant_table_dir, f"{ping.identifier}.json"), "w").write(
-                    json.dumps(
+                    dump_json(
                         dict(
                             bq_definition=bq_definition,
                             bq_schema=bq_schema,
@@ -378,7 +372,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
         for ping_data in app_data["pings"]:
             ping_data["variants"].sort(key=lambda v: USER_CHANNEL_PRIORITY[v["channel"]])
             open(os.path.join(app_ping_dir, f"{ping_data['name']}.json"), "w").write(
-                json.dumps(
+                dump_json(
                     _expand_tags(
                         _incorporate_annotation(
                             dict(
@@ -396,8 +390,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                             full=True,
                         ),
                         app_tags,
-                    ),
-                    default=_serialize_sets,
+                    )
                 )
             )
 
@@ -407,12 +400,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
             open(
                 os.path.join(app_metrics_dir, f"{_normalize_metrics(metric_data['name'])}.json"),
                 "w",
-            ).write(
-                json.dumps(
-                    metric_data,
-                    default=_serialize_sets,
-                )
-            )
+            ).write(dump_json(metric_data))
 
         # write tag metadata (if any)
         if app_tags:
@@ -440,7 +428,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                     app_data[key].sort(key=lambda v: v["metric_count"] > 0, reverse=True)
 
         open(os.path.join(app_dir, "index.json"), "w").write(
-            json.dumps(
+            dump_json(
                 _incorporate_annotation(
                     app_data, app_annotation.get("app", {}), app=True, full=True
                 )
@@ -454,5 +442,5 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
 
     # also write some metadata for use by the netlify functions
     open(os.path.join(functions_dir, "supported_glam_metric_types.json"), "w").write(
-        json.dumps(list(SUPPORTED_GLAM_METRIC_TYPES))
+        dump_json(list(SUPPORTED_GLAM_METRIC_TYPES))
     )

--- a/etl/search.py
+++ b/etl/search.py
@@ -1,7 +1,8 @@
-import json
 from pathlib import Path
 
 import jinja2
+
+from .utils import dump_json
 
 SEARCH_JS_TEMPLATE = jinja2.Template(
     open(Path(__file__).resolve().parent / "metrics_search.js.tmpl").read()
@@ -21,4 +22,4 @@ def create_metrics_search_js(metrics, legacy=False):
         if metric_val.get("expires") == "never":
             del metric_val["expires"]
 
-    return SEARCH_JS_TEMPLATE.render(metric_data=json.dumps(metric_data), legacy=json.dumps(legacy))
+    return SEARCH_JS_TEMPLATE.render(metric_data=dump_json(metric_data), legacy=dump_json(legacy))

--- a/etl/utils.py
+++ b/etl/utils.py
@@ -1,0 +1,19 @@
+import json
+
+
+def _serialize_sets(obj):
+    if isinstance(obj, set):
+        return list(obj)
+    return obj
+
+
+def dump_json(data):
+    """
+    Utility function for dumping json data
+
+    There are two differences from a plain call to json.dumps:
+
+    1. Sets are serialized to lists
+    2. We dump the data without spaces (since we want things as small as possible)
+    """
+    return json.dumps(data, separators=(",", ":"), default=_serialize_sets)

--- a/etl_tests/test_search.py
+++ b/etl_tests/test_search.py
@@ -28,6 +28,9 @@ def test_create_metrics_search_js():
             "description": "Fun Metric 2",
         },
     }
+
+    # this implicitly also tests utils.dump_json
     assert create_metrics_search_js(metrics_input) == SEARCH_JS_TEMPLATE.render(
-        metric_data=json.dumps(expected_metrics_output), legacy=json.dumps(False)
+        metric_data=json.dumps(expected_metrics_output, separators=(",", ":")),
+        legacy=json.dumps(False),
     )


### PR DESCRIPTION
This brings down the size of the firefox legacy metrics search
function from 1053888 bytes down to 1017557 bytes. Not a huge
improvement, but why not.
