### PR TITLE
Better breadcrumbs and titles

### DIFF
--- a/playwright/test.spec.js
+++ b/playwright/test.spec.js
@@ -7,11 +7,40 @@ test("first playwright test", async ({ page }) => {
 
 test("metrics ping page", async ({ page }) => {
   await page.goto("http://localhost:5000/apps/fenix/pings/metrics");
-  await expect(page).toHaveTitle("metrics | fenix");
+  await expect(page).toHaveTitle("metrics | Firefox for Android");
 
   // we expect a selector starting with our looker URL, directing to an explore
   // containing the word "metrics" corresponding to the ping
   await expect(
     page.locator('a[href^="https://mozilla.cloud.looker"]')
   ).toContainText("metrics");
+});
+
+test("activation id metric page", async ({ page }) => {
+  await page.goto(
+    "http://localhost:5000/apps/fenix/metrics/activation_activation_id"
+  );
+  await expect(page).toHaveTitle(
+    "activation.activation_id | Firefox for Android"
+  );
+
+  // we expect a selector starting with our looker URL, directing to an explore
+  // containing the word "metrics" corresponding to the metric
+  await expect(
+    page.locator('a[href^="https://mozilla.cloud.looker"]').last()
+  ).toContainText("activation_id");
+});
+
+test("org.mozilla.fenix app id page", async ({ page }) => {
+  await page.goto("http://localhost:5000/apps/fenix/app_ids/org_mozilla_fenix");
+  await expect(page).toHaveTitle("org.mozilla.fenix | Firefox for Android");
+});
+
+test("activation table page", async ({ page }) => {
+  await page.goto(
+    "http://localhost:5000/apps/fenix/app_ids/org_mozilla_fenix/tables/activation"
+  );
+  await expect(page).toHaveTitle(
+    "org_mozilla_fenix.activation | org.mozilla.fenix | Firefox for Android"
+  );
 });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,6 @@
 <script>
   import page from "page";
   import { parse as queryStringParse } from "query-string";
-  import { afterUpdate } from "svelte";
 
   import { submitPageViewTelemetry } from "./telemetry";
 
@@ -19,46 +18,12 @@
   import GlobalStyles from "./GlobalStyles.svelte";
 
   // Stores
-  import { pageState, pageTitle } from "./state/stores";
+  import { pageState, pageTitle, pageBreadcrumbs } from "./state/stores";
 
   let component;
   let params = {};
-  let links = [];
 
   let title;
-
-  afterUpdate(() => {
-    const { app, appId, ping, metric, table } = params;
-
-    links = [
-      ...(app
-        ? [
-            { url: "/", name: "apps" },
-            { url: `/apps/${app}/`, name: app },
-          ]
-        : []),
-      ...(appId
-        ? [{ url: `/apps/${app}/app_ids/${appId}/`, name: appId }]
-        : []),
-      ...(ping ? [{ url: `/apps/${app}/pings/${ping}/`, name: ping }] : []),
-      ...(metric
-        ? [
-            {
-              url: `/apps/${app}/metrics/${metric}/`,
-              name: metric.replaceAll("-", "."),
-            },
-          ]
-        : []),
-      ...(table
-        ? [
-            {
-              url: `/apps/${app}/app_ids/${appId}/tables/${table}/`,
-              name: table,
-            },
-          ]
-        : []),
-    ];
-  });
 
   function setComponent(c) {
     return function setComponentInner(ctx) {
@@ -86,6 +51,7 @@
   // https://stackoverflow.com/a/59028538
 
   $: title = $pageTitle ? `${$pageTitle}` : "Glean Dictionary";
+  $: breadCrumbLinks = $pageBreadcrumbs;
   $: document.title = title;
 </script>
 
@@ -106,9 +72,9 @@
       </div>
     </div>
   </header>
-  {#if links.length}
+  {#if breadCrumbLinks.length}
     <nav class="mzp-c-navigation breadcrumb">
-      <Breadcrumb {links} />
+      <Breadcrumb links={breadCrumbLinks} />
     </nav>
   {/if}
   <main>

--- a/src/components/Breadcrumb.svelte
+++ b/src/components/Breadcrumb.svelte
@@ -1,22 +1,20 @@
 <script>
+  import { some } from "lodash";
+
   export let links;
 
-  const isPlatform = (app) => {
-    const platforms = ["ios", "android", "fenix", "amazon", "echo", "fire_tv"];
-    const match = platforms.filter((item) => app.includes(item));
-    if (match.length) return true;
-    return false;
+  const isPlatform = (link) => {
+    return some(
+      ["iOS", "Android", "Amazon"],
+      (platformTag) => link.tags && link.tags.includes(platformTag)
+    );
   };
 
-  const getPlatformLogo = (app) => {
-    if (app.includes("ios")) return "/img/app-logos/apple-breadcrumb.png";
-    if (app.includes("fenix") || app.includes("android"))
+  const getPlatformLogo = (link) => {
+    if (link.tags.includes("iOS")) return "/img/app-logos/apple-breadcrumb.png";
+    if (link.tags.includes("Android"))
       return "/img/app-logos/android-breadcrumb.png";
-    if (
-      app.includes("amazon") ||
-      app.includes("echo") ||
-      app.includes("fire_tv")
-    )
+    if (link.tags.includes("Amazon"))
       return "/img/app-logos/amazon-breadcrumb.png";
     return undefined;
   };
@@ -28,8 +26,8 @@
       <li>
         <a class="link-name" href={link.url}>{link.name} </a>
       </li>
-      {#if link && isPlatform(link.name)}
-        <img src={getPlatformLogo(link.name)} alt="Platform Logo" />{/if}
+      {#if isPlatform(link)}
+        <img src={getPlatformLogo(link)} alt="Platform Logo" />{/if}
       <span>{links.indexOf(link) === links.length - 1 ? "" : "->"}</span>
     {/each}
   </ol>

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -1,3 +1,15 @@
+<script context="module">
+  export const getAppBreadcrumbs = (params, obj) => {
+    return [
+      {
+        url: `/apps/${params.app}`,
+        name: obj.canonical_app_name,
+        tags: obj.app_tags,
+      },
+    ];
+  };
+</script>
+
 <script>
   import { getAppData } from "../state/api";
 
@@ -12,13 +24,18 @@
   import { TabGroup, Tab, TabContent } from "../components/tabs";
   import PageHeader from "../components/PageHeader.svelte";
   import SubHeading from "../components/SubHeading.svelte";
-  import { pageState, pageTitle, updateURLState } from "../state/stores";
+  import {
+    pageState,
+    updateURLState,
+    updateBreadcrumbs,
+  } from "../state/stores";
 
   export let params;
 
   let itemType;
 
   const appDataPromise = getAppData(params.app).then((app) => {
+    updateBreadcrumbs(getAppBreadcrumbs(params, app));
     return {
       ...app,
       tagDescriptions: Object.fromEntries(
@@ -30,8 +47,6 @@
   $: {
     itemType = $pageState.itemType || "metrics";
   }
-
-  pageTitle.set(params.app);
 </script>
 
 {#await appDataPromise then app}

--- a/src/pages/AppIdDetail.svelte
+++ b/src/pages/AppIdDetail.svelte
@@ -1,3 +1,14 @@
+<script context="module">
+  import { getAppBreadcrumbs } from "./AppDetail.svelte";
+
+  export const getAppIdBreadcrumbs = (params, obj) => {
+    return [
+      ...getAppBreadcrumbs(params, obj),
+      { url: `/apps/${params.app}/app_ids/${params.appId}`, name: obj.app_id },
+    ];
+  };
+</script>
+
 <script>
   import { getAppIdData } from "../state/api";
 
@@ -5,23 +16,17 @@
   import MetadataTable from "../components/MetadataTable.svelte";
   import Label from "../components/Label.svelte";
   import PageHeader from "../components/PageHeader.svelte";
-  import { pageTitle } from "../state/stores";
+  import { updateBreadcrumbs } from "../state/stores";
   import { getDeprecatedItemDescription } from "../data/help";
 
   export let params;
 
-  function setTitle(appId, app) {
-    pageTitle.set(`${appId.app_id} | ${app}`);
-  }
-
   const appIdDataPromise = getAppIdData(params.app, params.appId).then(
     (appId) => {
-      setTitle(appId, params.app);
+      updateBreadcrumbs(getAppIdBreadcrumbs(params, appId));
       return appId;
     }
   );
-
-  setTitle(params.appId, params.app);
 </script>
 
 {#await appIdDataPromise then appId}

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -8,7 +8,7 @@
   import Markdown from "../components/Markdown.svelte";
   import Label from "../components/Label.svelte";
 
-  import { pageState, pageTitle } from "../state/stores";
+  import { pageState, updateBreadcrumbs } from "../state/stores";
 
   const URL = "data/apps.json";
 
@@ -46,7 +46,7 @@
     return undefined;
   }
 
-  pageTitle.set("Glean Dictionary");
+  updateBreadcrumbs([]);
 </script>
 
 <div class="mzp-c-emphasis-box mzp-t-dark banner">

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -25,8 +25,13 @@
   import { stripLinks } from "../formatters/markdown";
   import { getLibraryName } from "../formatters/library";
   import { getMetricData } from "../state/api";
-  import { pageTitle, pageState, updateURLState } from "../state/stores";
+  import {
+    pageState,
+    updateURLState,
+    updateBreadcrumbs,
+  } from "../state/stores";
   import { getBigQueryURL, getMetricSearchURL } from "../state/urls";
+  import { getAppBreadcrumbs } from "./AppDetail.svelte";
 
   import { isExpired, isRemoved, isRecent } from "../state/items";
 
@@ -38,6 +43,13 @@
 
   const metricDataPromise = getMetricData(params.app, params.metric).then(
     (metricData) => {
+      updateBreadcrumbs([
+        ...getAppBreadcrumbs(params, metricData),
+        {
+          url: `/apps/${params.app}/metrics/${params.metric}/`,
+          name: metricData.name,
+        },
+      ]);
       [selectedAppVariant] = $pageState.channel
         ? metricData.variants.filter((app) => app.id === $pageState.channel)
         : metricData.variants;
@@ -54,8 +66,6 @@
       selectedPingVariant &&
       selectedAppVariant.etl.ping_data[selectedPingVariant.id];
   }
-
-  pageTitle.set(`${params.metric} | ${params.app} `);
 
   function getMetricDocumentationURI(type) {
     const sourceDocs = "https://mozilla.github.io/glean/book/user/metrics/";

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -1,6 +1,10 @@
 <script>
   import { getPingData } from "../state/api";
-  import { pageState, pageTitle, updateURLState } from "../state/stores";
+  import {
+    pageState,
+    updateURLState,
+    updateBreadcrumbs,
+  } from "../state/stores";
   import { getBigQueryURL } from "../state/urls";
 
   import VariantSelector from "../components/VariantSelector.svelte";
@@ -24,20 +28,27 @@
   import { stripLinks } from "../formatters/markdown";
   import { getMetricSearchURL } from "../state/urls";
   import { isRecent } from "../state/items";
+  import { getAppBreadcrumbs } from "./AppDetail.svelte";
 
   export let params;
 
   let selectedAppVariant;
   const pingDataPromise = getPingData(params.app, params.ping).then(
     (pingData) => {
+      updateBreadcrumbs([
+        ...getAppBreadcrumbs(params, pingData),
+        {
+          url: `/apps/${params.app}/pings/${params.ping}/`,
+          name: pingData.name,
+        },
+      ]);
+
       [selectedAppVariant] = $pageState.channel
         ? pingData.variants.filter((app) => app.id === $pageState.channel)
         : pingData.variants;
       return pingData;
     }
   );
-
-  pageTitle.set(`${params.ping} | ${params.app}`);
 </script>
 
 {#await pingDataPromise then ping}

--- a/src/pages/TableDetail.svelte
+++ b/src/pages/TableDetail.svelte
@@ -3,16 +3,30 @@
   import SchemaViewer from "../components/SchemaViewer.svelte";
   import SubHeading from "../components/SubHeading.svelte";
   import { getTableData } from "../state/api";
-  import { pageTitle } from "../state/stores";
+  import { updateBreadcrumbs } from "../state/stores";
 
   import NotFound from "../components/NotFound.svelte";
   import PageHeader from "../components/PageHeader.svelte";
 
+  import { getAppIdBreadcrumbs } from "./AppIdDetail.svelte";
+
   export let params;
 
-  const pingDataPromise = getTableData(params.app, params.appId, params.table);
+  const pingDataPromise = getTableData(
+    params.app,
+    params.appId,
+    params.table
+  ).then((tableData) => {
+    updateBreadcrumbs([
+      ...getAppIdBreadcrumbs(params, tableData),
+      {
+        url: `/apps/${params.app}/app_ids/${params.appId}/tables/${params.table}/`,
+        name: tableData.stable_table,
+      },
+    ]);
 
-  pageTitle.set(`${params.table} table | ${params.appId}`);
+    return tableData;
+  });
 </script>
 
 {#await pingDataPromise then table}

--- a/src/state/stores.js
+++ b/src/state/stores.js
@@ -4,6 +4,7 @@ import { writable, get } from "svelte/store";
 
 export const pageTitle = writable("");
 export const pageState = writable({});
+export const pageBreadcrumbs = writable([]);
 
 // updates page state and synchronizes with the url
 export const updateURLState = (newState, push = false) => {
@@ -24,5 +25,23 @@ export const updateURLState = (newState, push = false) => {
     window.history.pushState(null, undefined, path);
   } else {
     window.history.replaceState(null, undefined, path);
+  }
+};
+
+export const updateBreadcrumbs = (newBreadcrumbs) => {
+  if (newBreadcrumbs.length > 0) {
+    // add a breadcrumb to return to the root
+    pageBreadcrumbs.set([{ url: "/", name: "apps" }, ...newBreadcrumbs]);
+    // set a pagetitle in reverse order
+    pageTitle.set(
+      newBreadcrumbs
+        .slice(0)
+        .reverse()
+        .map((b) => b.name)
+        .join(" | ")
+    );
+  } else {
+    pageBreadcrumbs.set([]);
+    pageTitle.set("Glean Dictionary");
   }
 };

--- a/stories/breadcrumb.stories.js
+++ b/stories/breadcrumb.stories.js
@@ -4,16 +4,16 @@ const [AppsLinks, AppDetailsLinks, PingsLinks, MetricsLinks, TableLinks] = [
   [{ url: "/", name: "apps" }],
   [
     { url: "/", name: "apps" },
-    { url: "/apps/fenix/", name: "fenix" },
+    { url: "/apps/fenix/", name: "fenix", tags: ["Android"] },
   ],
   [
     { url: "/", name: "apps" },
-    { url: "/apps/fenix/", name: "fenix" },
+    { url: "/apps/fenix/", name: "fenix", tags: ["Android"] },
     { url: "/apps/fenix/pings/activation", name: "activation" },
   ],
   [
     { url: "/", name: "apps" },
-    { url: "/apps/fenix/", name: "fenix" },
+    { url: "/apps/fenix/", name: "fenix", tags: ["Android"] },
     {
       url: "/apps/fenix/metrics/about_page.libraries_tapped",
       name: "about_page.libraries_tapped",
@@ -21,7 +21,7 @@ const [AppsLinks, AppDetailsLinks, PingsLinks, MetricsLinks, TableLinks] = [
   ],
   [
     { url: "/", name: "apps" },
-    { url: "/apps/fenix/", name: "fenix" },
+    { url: "/apps/fenix/", name: "fenix", tags: ["Android"] },
     { url: "/apps/fenix/pings/activation", name: "activation" },
     { url: "/apps/fenix/tables/activation/", name: "activation table" },
   ],


### PR DESCRIPTION
Use the *actual* data for the applications, metrics, etc. in the titles and breadcrumbs, not the normalized values derived from the URL.
    
This also fixes a few bugs around when/where to apply the android/ios tags to the breadcrumbs by using the app metadata instead of inferring it from the title.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
