### PR TITLE
Get glean source tags from environment at build time

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -103,6 +103,7 @@ export default {
       ),
       GLEAN_LOG_PINGS: !!process.env.GLEAN_LOG_PINGS,
       GLEAN_DEBUG_VIEW_TAG: process.env.GLEAN_DEBUG_VIEW_TAG,
+      GLEAN_SOURCE_TAGS: process.env.GLEAN_SOURCE_TAGS,
       __DISPLAY_VERSION__: execSync("git describe --abbrev=0 --tags")
         .toString()
         .trim(),


### PR DESCRIPTION
Fixes #1046.

Turns out I had already implemented the part that uses the source tags in my previous PR: https://github.com/mozilla/glean-dictionary/blob/main/src/telemetry/index.js#L53-L57. Ok then.

For future reference, me and @Iinh have already worked on setting this tag to `automation` on the Netlify PR deploys.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
