### PR TITLE
Bug 1748204 - Remove trailing `/` chars from path when recording to Glean

### DIFF
--- a/src/telemetry/index.js
+++ b/src/telemetry/index.js
@@ -71,6 +71,7 @@ export function submitPageViewTelemetry(path) {
 
   // Send telemetry to Glean.
   pageMetrics.loaded.set();
-  pageMetrics.path.set(path.split("?")[0]);
+  // Remove query params and trailing `/` characters.
+  pageMetrics.path.set(path.split("?")[0].replace(/\/$/, ""));
   pageViewPing.submit();
 }


### PR DESCRIPTION
If we don't remove the trailing `/` paths like `apps/fenix` and
`apps/fenix/` are counted as different paths wich is not very
productive.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
