### PR TITLE
Handle tags without a definition (fixes #1066)

### DIFF
--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -99,7 +99,7 @@ def _expand_tags(item, tag_descriptions):
     return dict(
         item,
         tags=[
-            {"name": tag_name, "description": tag_descriptions[tag_name]}
+            {"name": tag_name, "description": tag_descriptions.get(tag_name, "Unknown tag")}
             for tag_name in item["tags"]
         ],
     )


### PR DESCRIPTION
This is probably not the ideal solution (we would ideally have some
kind of automation / warning system to pick this up), but this is better
than just failing. Tags are essentially just documentation and we don't
have any validation right now on the probe-scraper level that they're
set.
