### PR TITLE
Slightly reduce the size of generated json by omitting spaces

### DIFF
--- a/etl/search.py
+++ b/etl/search.py
@@ -1,7 +1,8 @@
-import json
 from pathlib import Path
 
 import jinja2
+
+from .utils import dump_json
 
 SEARCH_JS_TEMPLATE = jinja2.Template(
     open(Path(__file__).resolve().parent / "metrics_search.js.tmpl").read()
@@ -21,4 +22,4 @@ def create_metrics_search_js(metrics, legacy=False):
         if metric_val.get("expires") == "never":
             del metric_val["expires"]
 
-    return SEARCH_JS_TEMPLATE.render(metric_data=json.dumps(metric_data), legacy=json.dumps(legacy))
+    return SEARCH_JS_TEMPLATE.render(metric_data=dump_json(metric_data), legacy=dump_json(legacy))

--- a/etl/utils.py
+++ b/etl/utils.py
@@ -1,0 +1,19 @@
+import json
+
+
+def _serialize_sets(obj):
+    if isinstance(obj, set):
+        return list(obj)
+    return obj
+
+
+def dump_json(data):
+    """
+    Utility function for dumping json data
+
+    There are two differences from a plain call to json.dumps:
+
+    1. Sets are serialized to lists
+    2. We dump the data without spaces (since we want things as small as possible)
+    """
+    return json.dumps(data, separators=(",", ":"), default=_serialize_sets)

--- a/etl_tests/test_search.py
+++ b/etl_tests/test_search.py
@@ -28,6 +28,9 @@ def test_create_metrics_search_js():
             "description": "Fun Metric 2",
         },
     }
+
+    # this implicitly also tests utils.dump_json
     assert create_metrics_search_js(metrics_input) == SEARCH_JS_TEMPLATE.render(
-        metric_data=json.dumps(expected_metrics_output), legacy=json.dumps(False)
+        metric_data=json.dumps(expected_metrics_output, separators=(",", ":")),
+        legacy=json.dumps(False),
     )


### PR DESCRIPTION
This brings down the size of the firefox legacy metrics search
function from 1053888 bytes down to 1017557 bytes. Not a huge
improvement, but why not.
