### PR TITLE
Use toBe instead of toEqual in jest

### DIFF
--- a/tests/formatters.codesearch.test.js
+++ b/tests/formatters.codesearch.test.js
@@ -2,12 +2,12 @@ import { getCodeSearchLink } from "../src/formatters/codesearch";
 
 describe("Searchfox links for firefox-desktop", () => {
   it("works as expected", () => {
-    expect(getCodeSearchLink("firefox_desktop", "test.metric_name")).toEqual(
+    expect(getCodeSearchLink("firefox_desktop", "test.metric_name")).toBe(
       "https://searchfox.org/mozilla-central/search?q=test.metric_name|test.metricName|Test.metricName|test.metric_name|test::metric_name&regexp=true"
     );
     expect(
       getCodeSearchLink("firefox_desktop", "test_category.test_name")
-    ).toEqual(
+    ).toBe(
       "https://searchfox.org/mozilla-central/search?q=test_category.test_name|testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&regexp=true"
     );
   });
@@ -15,10 +15,10 @@ describe("Searchfox links for firefox-desktop", () => {
 
 describe("Searchfox links for applications in mozilla-mobile", () => {
   it("works as expected", () => {
-    expect(getCodeSearchLink("fenix", "test.metric_name")).toEqual(
+    expect(getCodeSearchLink("fenix", "test.metric_name")).toBe(
       "https://searchfox.org/mozilla-mobile/search?q=test.metric_name|test.metricName|Test.metricName|test.metric_name|test::metric_name&path=fenix&regexp=true"
     );
-    expect(getCodeSearchLink("fenix", "test_category.test_name")).toEqual(
+    expect(getCodeSearchLink("fenix", "test_category.test_name")).toBe(
       "https://searchfox.org/mozilla-mobile/search?q=test_category.test_name|testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&path=fenix&regexp=true"
     );
   });
@@ -26,7 +26,7 @@ describe("Searchfox links for applications in mozilla-mobile", () => {
 
 describe("returns Sourcegraph link if the application is not indexed on Searchfox", () => {
   it("works as expected", () => {
-    expect(getCodeSearchLink("mozregression", "usage.bad_date")).toEqual(
+    expect(getCodeSearchLink("mozregression", "usage.bad_date")).toBe(
       "https://sourcegraph.com/search?q=repo:%5Egithub%5C.com%5C/%5BMm%5Dozilla%28.*%29%5C/mozregression%24+usage.bad_date|usage.badDate|Usage.badDate|usage.bad_date|usage::bad_date&patternType=regexp"
     );
   });

--- a/tests/formatters.emails.test.js
+++ b/tests/formatters.emails.test.js
@@ -2,8 +2,6 @@ import { getEmailLink } from "../src/formatters/emails";
 
 describe("Email link generation", () => {
   it("works as expected", () => {
-    expect(getEmailLink("gecko@mozilla.com")).toEqual(
-      "mailto:gecko@mozilla.com"
-    );
+    expect(getEmailLink("gecko@mozilla.com")).toBe("mailto:gecko@mozilla.com");
   });
 });

--- a/tests/formatters.links.test.js
+++ b/tests/formatters.links.test.js
@@ -2,14 +2,14 @@ import { getBugLinkTitle, getSourceUrlTitle } from "../src/formatters/links";
 
 describe("Titles for bugzilla URLs", () => {
   it("works as expected", () => {
-    expect(getBugLinkTitle("https://bugzilla.mozilla.org/1234")).toEqual(
+    expect(getBugLinkTitle("https://bugzilla.mozilla.org/1234")).toBe(
       "bugzil.la/1234"
     );
-    expect(getBugLinkTitle("https://bugzilla.mozilla.org/1234#c23")).toEqual(
+    expect(getBugLinkTitle("https://bugzilla.mozilla.org/1234#c23")).toBe(
       "bugzil.la/1234#c23"
     );
-    expect(getBugLinkTitle("https://bugzil.la/1234")).toEqual("bugzil.la/1234");
-    expect(getBugLinkTitle("https://bugzil.la/show_bug.cgi?id=1234")).toEqual(
+    expect(getBugLinkTitle("https://bugzil.la/1234")).toBe("bugzil.la/1234");
+    expect(getBugLinkTitle("https://bugzil.la/show_bug.cgi?id=1234")).toBe(
       "bugzil.la/1234"
     );
   });
@@ -19,18 +19,18 @@ describe("Titles for github URLs", () => {
   it("works as expected", () => {
     expect(
       getBugLinkTitle("https://github.com/mozilla-mobile/fenix/issues/1234")
-    ).toEqual("mozilla-mobile/fenix#1234");
+    ).toBe("mozilla-mobile/fenix#1234");
     expect(
       getBugLinkTitle(
         "https://github.com/mozilla-mobile/fenix/issues/1234#issuecomment-5678"
       )
-    ).toEqual("mozilla-mobile/fenix#1234-comment");
+    ).toBe("mozilla-mobile/fenix#1234-comment");
   });
 });
 
 describe("Titles for other issue tracker URLs", () => {
   it("works as expected", () => {
-    expect(getBugLinkTitle("https://jira.com/1234")).toEqual("jira.com/1234");
+    expect(getBugLinkTitle("https://jira.com/1234")).toBe("jira.com/1234");
   });
 });
 
@@ -40,6 +40,6 @@ describe("Titles for source definition", () => {
       getSourceUrlTitle(
         "https://github.com/mozilla-mobile/fenix/blob/b01dbeeebf2b54dabbb1b60916bee4ec2c837b5f/app/metrics.yaml#L1234"
       )
-    ).toEqual("mozilla-mobile/fenix/app/metrics.yaml#L1234");
+    ).toBe("mozilla-mobile/fenix/app/metrics.yaml#L1234");
   });
 });

--- a/tests/state.items.test.js
+++ b/tests/state.items.test.js
@@ -2,33 +2,33 @@ import { isExpired, isRemoved, isRecent } from "../src/state/items";
 
 describe("checking if a date has expired", () => {
   it("returns True if input is 'never' or undefined", () => {
-    expect(isExpired({ expires: "never" }) || isExpired({})).toEqual(false);
+    expect(isExpired({ expires: "never" }) || isExpired({})).toBe(false);
   });
   it("returns True if input is a date from the past", () => {
-    expect(isExpired({ expires: "2021-01-01" })).toEqual(true);
+    expect(isExpired({ expires: "2021-01-01" })).toBe(true);
   });
   it("returns False if input is a date from the future", () => {
-    expect(isExpired({ expires: "3021-01-01" })).toEqual(false);
+    expect(isExpired({ expires: "3021-01-01" })).toBe(false);
   });
 });
 
 describe("isRemoved works as expected", () => {
   it("returns true if in_source is false", () => {
-    expect(isRemoved({ in_source: false })).toEqual(true);
+    expect(isRemoved({ in_source: false })).toBe(true);
   });
   it("returns false if in_source is undefined", () => {
-    expect(isRemoved({})).toEqual(false);
+    expect(isRemoved({})).toBe(false);
   });
   it("returns false if in_source is true", () => {
-    expect(isRemoved({ in_source: true })).toEqual(false);
+    expect(isRemoved({ in_source: true })).toBe(false);
   });
 });
 
 describe("checking if a date is recent", () => {
   it("returns True if it's less than 30 days ago", () => {
-    expect(isRecent({ date_first_seen: new Date() })).toEqual(true);
+    expect(isRecent({ date_first_seen: new Date() })).toBe(true);
   });
   it("returns False if more than 30 days have passed", () => {
-    expect(isRecent({ date_first_seen: "2021-01-01 00:00:00" })).toEqual(false);
+    expect(isRecent({ date_first_seen: "2021-01-01 00:00:00" })).toBe(false);
   });
 });

--- a/tests/state.urls.test.js
+++ b/tests/state.urls.test.js
@@ -2,7 +2,7 @@ import { getItemURL, getBigQueryURL } from "../src/state/urls";
 
 describe("metric URL replacing", () => {
   it("works as expected", () => {
-    expect(getItemURL("foo", "metrics", "bar.baz")).toEqual(
+    expect(getItemURL("foo", "metrics", "bar.baz")).toBe(
       "/apps/foo/metrics/bar_baz"
     );
   });
@@ -17,13 +17,13 @@ describe("getting bigquery urls", () => {
         "activation",
         "activation.activation_id"
       )
-    ).toEqual(
+    ).toBe(
       "/apps/fenix/app_ids/org_mozilla_fenix/tables/activation?search=activation.activation_id"
     );
   });
 
   it("works as expected when you don't provide a metric name", () => {
-    expect(getBigQueryURL("fenix", "org.mozilla.fenix", "activation")).toEqual(
+    expect(getBigQueryURL("fenix", "org.mozilla.fenix", "activation")).toBe(
       "/apps/fenix/app_ids/org_mozilla_fenix/tables/activation"
     );
   });


### PR DESCRIPTION
[Latest CI failures](https://app.circleci.com/pipelines/github/mozilla/glean-dictionary) complained that we need to start using toBe instead of toEqual when comparing primitive literals.

<img width="967" alt="CleanShot 2022-02-02 at 16 06 49@2x" src="https://user-images.githubusercontent.com/28797553/152237426-a0aeb44d-89dc-4495-8eb9-e1968561bb5c.png">


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
