### PR TITLE
Bug 1751483 - Document iOS third-party data collection

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -21,6 +21,8 @@
     getLibraryDescription,
   } from "../data/help";
 
+  import { adjustDataTypes } from "./iOSThirdPartyData.svelte";
+
   import { fullTextSearch } from "../state/search";
 
   let DEFAULT_ITEMS_PER_PAGE = 20;
@@ -194,8 +196,11 @@
                       clickable
                     />
                   {:else}
-                    <a href={getItemURL(appName, itemType, item.name)}
-                      >{@html highlightSearch(item.name, search)}</a
+                    <a
+                      href={getItemURL(appName, itemType, item.name)}
+                      style={itemType === "third-party data"
+                        ? "pointer-events: none"
+                        : ""}>{@html highlightSearch(item.name, search)}</a
                     >
                   {/if}
                   {#if item.origin && item.origin !== appName}
@@ -213,10 +218,14 @@
                     {#each item.tags as tag}
                       <Label
                         text={tag}
-                        description={stripLinks(tagDescriptions[tag])}
                         clickable
                         on:click={updateSearch(`tags:${tag}`)}
                       />
+                    {/each}
+                  {/if}
+                  {#if item.types}
+                    {#each item.types as type}
+                      <Label text={type} description={adjustDataTypes[type]} />
                     {/each}
                   {/if}
                   {#if isRemoved(item)}

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -218,6 +218,7 @@
                     {#each item.tags as tag}
                       <Label
                         text={tag}
+                        description={stripLinks(tagDescriptions[tag])}
                         clickable
                         on:click={updateSearch(`tags:${tag}`)}
                       />

--- a/src/components/iOSThirdPartyData.svelte
+++ b/src/components/iOSThirdPartyData.svelte
@@ -1,0 +1,147 @@
+<script context="module">
+  export const adjustDataTypes = {
+    // used for label description
+    Advertising: "Information about Advertising",
+    Installation: "Information about how the application was installed",
+    Application:
+      "Information about the version and build of the application and its bundle ID",
+    Device: "Information about the make and model of your device",
+    User: "Information about the user",
+  };
+</script>
+
+<script>
+  import ItemList from "./ItemList.svelte";
+
+  // the Adjust data is hard-coded here as only Firefox iOS requires it atm
+  // when the need grows then we can start abstracting it
+  const adjustData = [
+    {
+      name: "adid",
+      description:
+        "The advertising identifier, specific to Mozilla, and managed using Apple's skAdNetwork API",
+      types: ["Advertising"],
+    },
+    {
+      name: "attribution_deeplink",
+      description: "Used to attribute a deeplink campaign",
+      types: ["Advertising"],
+    },
+    {
+      name: "engagement_type",
+      description:
+        "Used to attribute to a campaign that would otherwise be considered organic",
+      types: ["Advertising"],
+    },
+    {
+      name: "reference_tag",
+      description: "The click ID for the campaign",
+      types: ["Advertising"],
+    },
+    {
+      name: "tracker_token",
+      description: "Linking the install to the ads exposed",
+      types: ["Advertising"],
+    },
+    {
+      name: "event_token",
+      description: "Information about how the application was installed",
+      types: ["Installation"],
+    },
+    {
+      name: "event_cost_id",
+      description: "Information about how the application was installed",
+      types: ["Installation"],
+    },
+    {
+      name: "store_name",
+      description: "Information about how the application was installed",
+      types: ["Installation"],
+    },
+    {
+      name: "app_name",
+      description: "",
+      types: ["Application"],
+    },
+    {
+      name: "app_token",
+      description: "",
+      types: ["Application"],
+    },
+    {
+      name: "app_version",
+      description: "",
+      types: ["Application"],
+    },
+    {
+      name: "app_version_short",
+      description: "",
+      types: ["Application"],
+    },
+    {
+      name: "bundle_id",
+      description: "",
+      types: ["Application"],
+    },
+    {
+      name: "environment",
+      description: "",
+      types: ["Application"],
+    },
+    {
+      name: "user_id",
+      description: "A randomly generated user ID to identify you to Adjust",
+      types: ["User"],
+    },
+    {
+      name: "time_spent",
+      description: "The length of time the application is in the foreground",
+      types: ["User"],
+    },
+    {
+      name: "device_name",
+      description: "",
+      types: ["Device"],
+    },
+    {
+      name: "device_type",
+      description: "",
+      types: ["Device"],
+    },
+    {
+      name: "manufacturer",
+      description: "",
+      types: ["Device"],
+    },
+    {
+      name: "os_name",
+      description: "",
+      types: ["Device"],
+    },
+    {
+      name: "os_version",
+      description: "",
+      types: ["Device"],
+    },
+    {
+      name: "platform",
+      description: "",
+      types: ["Device"],
+    },
+  ];
+</script>
+
+<h4>Adjust Data</h4>
+<p>
+  Firefox iOS also uses Adjust — a mobile marketing vendor — to collect data
+  that's used to determine the origin of the installation. For more information,
+  see <a
+    href="https://support.mozilla.org/en-US/kb/how-do-you-use-adjust-firefox"
+    >"How do you use Adjust in Firefox?"</a
+  >
+</p>
+<ItemList
+  itemType="third-party data"
+  items={adjustData}
+  appName="firefox_ios"
+/>

--- a/src/pages/AppDetail.svelte
+++ b/src/pages/AppDetail.svelte
@@ -24,6 +24,7 @@
   import { TabGroup, Tab, TabContent } from "../components/tabs";
   import PageHeader from "../components/PageHeader.svelte";
   import SubHeading from "../components/SubHeading.svelte";
+  import ThirdPartyData from "../components/iOSThirdPartyData.svelte";
   import {
     pageState,
     updateURLState,
@@ -98,6 +99,10 @@
       <Tab key="tags">Tags</Tab>
     {/if}
     <Tab key="app_ids">Application IDs</Tab>
+    {#if app.app_name === "firefox_ios"}
+      <!-- for now, only Firefox iOS uses third-party data collection -->
+      <Tab key="third_party_data">Third-Party Data</Tab>
+    {/if}
 
     <TabContent key="tags">
       <ItemList itemType="tags" items={app.tags} appName={app.app_name} />
@@ -128,6 +133,9 @@
         appName={app.app_name}
         showFilter={false}
       />
+    </TabContent>
+    <TabContent key="third_party_data">
+      <ThirdPartyData />
     </TabContent>
   </TabGroup>
 {:catch}


### PR DESCRIPTION
Bugzilla [#1751483](https://bugzilla.mozilla.org/show_bug.cgi?id=1751483).

Firefox iOS is rolling out Adjust data collection this week. As required by our privacy policy, we need to document the use of this service data collection in the Glean Dictionary. This first-pass implementation adds a Third-Party Data tab to the Firefox iOS page. 

[Deploy preview](https://deploy-preview-1141--glean-dictionary-dev.netlify.app/apps/firefox_ios?itemType=third_party_data&page=1)

<img width="836" alt="CleanShot 2022-02-14 at 12 56 41@2x" src="https://user-images.githubusercontent.com/28797553/153919875-ecaca9b1-830d-4493-a3d4-9c7ee0145539.png">


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
