### PR TITLE
Handle stripLinks edge case (when input is undefined)

### DIFF
--- a/src/formatters/markdown.js
+++ b/src/formatters/markdown.js
@@ -1,3 +1,3 @@
 export function stripLinks(text) {
-  return text.replace(/\[(.*)\]\(.*\)/, "$1");
+  return (text && text.replace(/\[(.*)\]\(.*\)/, "$1")) || text;
 }

--- a/src/formatters/markdown.js
+++ b/src/formatters/markdown.js
@@ -1,3 +1,3 @@
 export function stripLinks(text) {
-  return (text && text.replace(/\[(.*)\]\(.*\)/, "$1")) || text;
+  return text?.replace(/\[(.*)\]\(.*\)/, "$1") || "";
 }


### PR DESCRIPTION
This URL, https://dictionary.telemetry.mozilla.org/apps/fenix?page=1&search=fog, which searches for any metric names with "fog", failed. The reason is because we currently don't provide any FOG tag description in Fenix metadata yet, so certain input for the stripLinks method (which is used to strip URLs from the tag description) was `undefined`. This PR adds a condition to make sure that we only strip links if the input exists.

Working example: https://deploy-preview-1162--glean-dictionary-dev.netlify.app/apps/fenix?page=1&search=fog

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
