### PR TITLE
Consolidate legacy telemetry and FOG search API

### DIFF
--- a/etl/firefox_legacy_etl.py
+++ b/etl/firefox_legacy_etl.py
@@ -78,4 +78,3 @@ def write_firefox_legacy_metadata(output_dir, functions_dir):
     open(os.path.join(functions_dir, "metrics_search_fog_and_legacy.js"), "w").write(
         create_metrics_search_js(probe_summary.values(), app_name="fog_and_legacy", legacy=True)
     )
-

--- a/etl/firefox_legacy_etl.py
+++ b/etl/firefox_legacy_etl.py
@@ -69,7 +69,13 @@ def write_firefox_legacy_metadata(output_dir, functions_dir):
         with open(os.path.join(probe_output_directory, f"data_{probe_name}.json"), "w") as f:
             json.dump(probe_metadata, f)
 
-    # write a search index for the app
+    # write a search index for legacy telemetry data
     open(os.path.join(functions_dir, "metrics_search_firefox_legacy.js"), "w").write(
         create_metrics_search_js(probe_summary.values(), legacy=True)
     )
+
+    # write a search index for legacy telemetry + FOG data
+    open(os.path.join(functions_dir, "metrics_search_fog_and_legacy.js"), "w").write(
+        create_metrics_search_js(probe_summary.values(), app_name="fog_and_legacy", legacy=True)
+    )
+

--- a/etl/fog.js.tmpl
+++ b/etl/fog.js.tmpl
@@ -1,0 +1,3 @@
+const fogData = {{ metric_data }};
+
+module.exports = { fogData };

--- a/etl/fog_and_legacy.js.tmpl
+++ b/etl/fog_and_legacy.js.tmpl
@@ -1,0 +1,8 @@
+const { getSearchFunction } = require("./search");
+const { fogData } = require("./metrics_search_fog");
+
+const metricData = {...{{ metric_data }}, ...fogData};
+
+const legacy = {{ legacy }};
+
+exports.handler = getSearchFunction(metricData, legacy);

--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -483,7 +483,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
         )
 
         # export FOG data to a separate file for the FOG + legacy search index
-        if app_name =="firefox_desktop": 
+        if app_name == "firefox_desktop":
             open(os.path.join(functions_dir, f"metrics_search_fog.js"), "w").write(
                 create_metrics_search_js(app_metrics.values(), app_name="fog", legacy=False)
             )

--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -479,8 +479,14 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
 
         # write a search index for the app
         open(os.path.join(functions_dir, f"metrics_search_{app_name}.js"), "w").write(
-            create_metrics_search_js(app_metrics.values(), legacy=False)
+            create_metrics_search_js(app_metrics.values(), app_name, legacy=False)
         )
+
+        # export FOG data to a separate file for the FOG + legacy search index
+        if app_name =="firefox_desktop": 
+            open(os.path.join(functions_dir, f"metrics_search_fog.js"), "w").write(
+                create_metrics_search_js(app_metrics.values(), app_name="fog", legacy=False)
+            )
 
     # Write out a list of app groups (for the landing page)
     # put "featured" apps first, then sort by name

--- a/etl/search.py
+++ b/etl/search.py
@@ -12,11 +12,14 @@ FOG_AND_LEGACY_SEARCH_JS_TEMPLATE = jinja2.Template(
     open(Path(__file__).resolve().parent / "fog_and_legacy.js.tmpl").read()
 )
 
-FOG_DATA_JS_TEMPLATE = jinja2.Template(
-    open(Path(__file__).resolve().parent / "fog.js.tmpl").read()
-)
+FOG_DATA_JS_TEMPLATE = jinja2.Template(open(Path(__file__).resolve().parent / "fog.js.tmpl").read())
+
 
 def create_metrics_search_js(metrics, app_name=None, legacy=False):
+    """
+    Take a list of metrics and create a search.js file for them.
+    """
+
     search_keys = (
         ["type", "description", "active"] if legacy else ["type", "description", "expires"]
     )
@@ -29,12 +32,19 @@ def create_metrics_search_js(metrics, app_name=None, legacy=False):
         if metric_val.get("expires") == "never":
             del metric_val["expires"]
 
+    # 'fog' app_name is a special case, it's holding data only instead of a search template.
+    # this is intended to be used with the combo legacy_and_fog search JS file.
+    # for more context see: https://github.com/mozilla/glean-dictionary/pull/1163#discussion_r824498324
     if app_name == "fog":
         for metric_val in metric_data.values():
-            metric_val["fog"] = True;
-        return FOG_DATA_JS_TEMPLATE.render(metric_data=dump_json(metric_data), legacy=dump_json(legacy))
+            metric_val["glean"] = True
+        return FOG_DATA_JS_TEMPLATE.render(
+            metric_data=dump_json(metric_data), legacy=dump_json(legacy)
+        )
 
     if app_name == "fog_and_legacy":
-        return FOG_AND_LEGACY_SEARCH_JS_TEMPLATE.render(metric_data=dump_json(metric_data), legacy=dump_json(legacy))
+        return FOG_AND_LEGACY_SEARCH_JS_TEMPLATE.render(
+            metric_data=dump_json(metric_data), legacy=dump_json(legacy)
+        )
 
     return SEARCH_JS_TEMPLATE.render(metric_data=dump_json(metric_data), legacy=dump_json(legacy))

--- a/etl/search.py
+++ b/etl/search.py
@@ -8,8 +8,15 @@ SEARCH_JS_TEMPLATE = jinja2.Template(
     open(Path(__file__).resolve().parent / "metrics_search.js.tmpl").read()
 )
 
+FOG_AND_LEGACY_SEARCH_JS_TEMPLATE = jinja2.Template(
+    open(Path(__file__).resolve().parent / "fog_and_legacy.js.tmpl").read()
+)
 
-def create_metrics_search_js(metrics, legacy=False):
+FOG_DATA_JS_TEMPLATE = jinja2.Template(
+    open(Path(__file__).resolve().parent / "fog.js.tmpl").read()
+)
+
+def create_metrics_search_js(metrics, app_name=None, legacy=False):
     search_keys = (
         ["type", "description", "active"] if legacy else ["type", "description", "expires"]
     )
@@ -21,5 +28,13 @@ def create_metrics_search_js(metrics, legacy=False):
             del metric_val["active"]
         if metric_val.get("expires") == "never":
             del metric_val["expires"]
+
+    if app_name == "fog":
+        for metric_val in metric_data.values():
+            metric_val["fog"] = True;
+        return FOG_DATA_JS_TEMPLATE.render(metric_data=dump_json(metric_data), legacy=dump_json(legacy))
+
+    if app_name == "fog_and_legacy":
+        return FOG_AND_LEGACY_SEARCH_JS_TEMPLATE.render(metric_data=dump_json(metric_data), legacy=dump_json(legacy))
 
     return SEARCH_JS_TEMPLATE.render(metric_data=dump_json(metric_data), legacy=dump_json(legacy))


### PR DESCRIPTION
The Glean Dictionary search service currently powers the search bar in GLAM. We have one search API per product:

- the legacy telemetry API [dictionary.telemetry.mozilla.org/api/v1/metrics_search_firefox_legacy?search=](https://dictionary.telemetry.mozilla.org/api/v1/metrics_search_firefox_legacy?search=techno) is used for desktop search
- [dictionary.telemetry.mozilla.org/api/v1/metrics_search_fenix?search=](dictionary.telemetry.mozilla.org/api/v1/metrics_search_fenix?search=) for Fenix search

As we're looking into adding FOG to GLAM, we need a way to let users search through FOG and legacy probes. One way to do it is to have 2 API calls each time a desktop search is performed, one to the legacy telemetry API and one to the FOG API. However, I propose that it would be better that on top of the existing APIs that we use per-product, we also create a single API that includes data for both legacy and FOG probes. This API will be used by the GLAM search for all desktop probes (legacy + FOG included). 

Working example of this new API:

https://deploy-preview-1163--glean-dictionary-dev.netlify.app/api/v1/metrics_search_fog_and_legacy?search=fog (searching for "fog" returns results of both legacy telemetry and FOG probes)

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
