### PR TITLE
Handle search terms with spaces in them (fixes #1099)

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -72,6 +72,10 @@
       : text;
   }
 
+  function quote(text) {
+    return text.includes(" ") ? `"${text}"` : text;
+  }
+
   $: {
     showUncollected = $pageState.showUncollected;
     search = $pageState.search || "";
@@ -192,7 +196,10 @@
                   {#if itemType === "tags"}
                     <Label
                       text={item.name}
-                      on:click={updateSearch(`tags:${item.name}`, "metrics")}
+                      on:click={updateSearch(
+                        `tags:${quote(item.name)}`,
+                        "metrics"
+                      )}
                       clickable
                     />
                   {:else}
@@ -220,7 +227,7 @@
                         text={tag}
                         description={stripLinks(tagDescriptions[tag])}
                         clickable
-                        on:click={updateSearch(`tags:${tag}`)}
+                        on:click={updateSearch(`tags:${quote(tag)}`)}
                       />
                     {/each}
                   {/if}

--- a/tests/state.search.test.js
+++ b/tests/state.search.test.js
@@ -43,6 +43,19 @@ const items = [
     type: "boolean",
     description: "def ghi",
   },
+  {
+    name: "metric.seven",
+    tags: ["Tag with spaces"],
+    origin: "engine-gecko",
+    type: "boolean",
+    description: "jkl mno",
+  },
+  {
+    name: "metric.eight",
+    origin: "engine-gecko",
+    type: "boolean",
+    description: "mno pqr stu",
+  },
 ];
 
 describe("search", () => {
@@ -74,5 +87,15 @@ describe("search", () => {
   it("works correctly with tags that has a `:` in its name", () =>
     expect(getNames(fullTextSearch("tags:A:Tag", items))).toEqual([
       "metric.six",
+    ]));
+
+  it("works correctly with tags with spaces", () =>
+    expect(getNames(fullTextSearch('tags:"Tag with spaces"', items))).toEqual([
+      "metric.seven",
+    ]));
+
+  it("exact match non-tokenized", () =>
+    expect(getNames(fullTextSearch('"mno pqr stu"', items))).toEqual([
+      "metric.eight",
     ]));
 });


### PR DESCRIPTION
Principally this is for handling tags with spaces, but also covers
a few other cases (e.g. exact match on description).
