### PR TITLE
Get metadata for legacy telemetry from beta if nightly doesn't exist

### DIFF
--- a/etl/firefox_legacy_etl.py
+++ b/etl/firefox_legacy_etl.py
@@ -25,11 +25,11 @@ def _get_legacy_firefox_metric_summary(probe_data, activity_mapping):
             # let's just skip legacy firefox events, since we're just doing
             # this for GLAM's benefit (which doesn't display events)
             continue
-        if not probe["history"].get("nightly"):
-            most_recent_metadata = probe["history"]["beta"][0]
-        else:
+        if probe["history"].get("nightly"):
             most_recent_metadata = probe["history"]["nightly"][0]
-        
+        else:
+            most_recent_metadata = probe["history"]["beta"][0]
+
         normalized_probe_name = probe["name"].lower().replace(".", "_")
         probe_summary[normalized_probe_name] = {
             "name": normalized_probe_name,


### PR DESCRIPTION
<img width="941" alt="CleanShot 2022-03-16 at 10 11 23@2x" src="https://user-images.githubusercontent.com/28797553/158609202-a95a6178-63b2-441a-a65c-2f8d763e7944.png">

The backend build process is failing (see [CI logs](https://app.circleci.com/pipelines/github/mozilla/glean-dictionary/3299/workflows/900c6f1d-1987-48a1-b028-418e02eaadfe/jobs/6354) from the last merged commit) due to a few newly added telemetry probes. We sourced metadata for legacy telemetry from the `nightly` channel, but for this one probe `scalar/contextual.services.quicksuggest.click_nonsponsored_bestmatch`, metadata only exists in `beta`.

See https://probeinfo.telemetry.mozilla.org/firefox/all/main/all_probes:

![CleanShot 2022-03-16 at 10 12 27@2x](https://user-images.githubusercontent.com/28797553/158609534-1c58bd7b-e713-4305-8e8e-1c84986811b9.png)

I'm assuming that for this probe, we only wanted data from beta? Will confirm with Data science to make sure.

Until then, this is meant to be a hotfix to get the build process up and running again. Long term we should consider adding a key to the metadata that specifies which channel we get the data from to make it more clear. 

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
