### PR TITLE
Install typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -282,6 +282,10 @@ tomli==1.2.2 \
     #   black
     #   pep517
     #   pytest
+typing-extensions==4.2.0 \
+    --hash=sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708 \
+    --hash=sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376
+    # via black
 urllib3==1.26.7 \
     --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
     --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844


### PR DESCRIPTION
CircleCI is currently failing due to the missing `typing-extensions` package.


<img width="1078" alt="CleanShot 2022-05-23 at 23 13 01@2x" src="https://user-images.githubusercontent.com/28797553/169941364-8a0431b1-cba8-4285-8c13-d59efe7a3f01.png">

