### PR TITLE
Don't link Firefox Desktop event metrics to event_counts explore

### DIFF
--- a/etl/looker.py
+++ b/etl/looker.py
@@ -87,7 +87,7 @@ def get_looker_explore_metadata_for_metric(
         _get_looker_event_explore(
             looker_namespaces, app.app_name, app.app.get("app_channel"), app_group
         )
-        if metric_type == "event"
+        if metric_type == "event" and app.app_name != "firefox_desktop"
         else _get_looker_ping_explore(
             looker_namespaces,
             app.app_name,
@@ -101,7 +101,7 @@ def get_looker_explore_metadata_for_metric(
     # we deliberately don't show looker information for deprecated applications
     if not app.app.get("deprecated") and base_looker_explore:
         looker_metric_link = None
-        if metric_type == "event":
+        if metric_type == "event" and app.app_name != "firefox_desktop":
             (metric_category, metric_name) = metric.identifier.split(".", 1)
             if base_looker_explore["name"] == "event_counts":
                 looker_metric_link = furl(base_looker_explore["url"]).add(


### PR DESCRIPTION
As described in #1389, currently we're linking Firefox Desktop event metrics to `event_counts` Looker explores, which is not correct. Until desktop event explores are created, let's not link `event` metrics to Looker yet.

Before: e.g. https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/nimbus_events_validation_failed

<img width="653" alt="CleanShot 2022-09-08 at 10 14 59@2x" src="https://user-images.githubusercontent.com/28797553/189145414-5a3f2a4d-a881-40a9-8ccd-e3f97e0b1192.png">

After: https://deploy-preview-1408--glean-dictionary-dev.netlify.app/apps/firefox_desktop/metrics/nimbus_events_validation_failed?ping=events

<img width="544" alt="CleanShot 2022-09-08 at 10 15 10@2x" src="https://user-images.githubusercontent.com/28797553/189145468-c37db10f-277a-435d-88f5-840e0bea3a0e.png">

