### PR TITLE
Enable filtering by metric types

### DIFF
--- a/src/components/FilterInput.svelte
+++ b/src/components/FilterInput.svelte
@@ -29,4 +29,7 @@
     border-radius: 15px;
     border: 1px solid #000;
   }
+  input::placeholder {
+    font-size: 13px;
+  }
 </style>

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -142,7 +142,9 @@
     </span>
   {/if}
   {#if showFilter}
-    <FilterInput placeHolder="Search {itemType}" />
+    <FilterInput
+      placeHolder="To search by metric type, tag, or origin: use [type:], [tags:] , or [origin:]. Example: `type:event addons`, `tags:Sync account, `origin:glean-core`"
+    />
   {/if}
   {#if !filteredItems.length}
     <div class="items-not-found">

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -26,11 +26,15 @@ export const fullTextSearch = (query, searchItems) => {
   let unlabeledsearchTerms = [];
 
   const searchTerms = query.match(/(?:(?:tags:)?".+")|"?[^ ]+"?/g);
-  const labels = { tags: [], origin: [] };
+  const labels = { tags: [], origin: [], type: [] };
   const searchIndex = generateSearchIndex(searchItems);
 
   searchTerms.forEach((term) => {
-    if (term.startsWith("tags:") || term.startsWith("origin:")) {
+    if (
+      term.startsWith("tags:") ||
+      term.startsWith("origin:") ||
+      term.startsWith("type:")
+    ) {
       const splitter = term.indexOf(":");
       const labelType = term.slice(0, splitter);
       labels[labelType] = [


### PR DESCRIPTION
Allow users to search explicitly by metric types using special syntax `type:<metric type>` (similar to how we filter by `tags:` or `origin:`).  Fixes #1462.

For example, `type: event` in the search bar will return only results of metric type `event`. See: https://deploy-preview-1466--glean-dictionary-dev.netlify.app/apps/fenix?page=1&search=type%3Aevent

Also, make it more visible that this functionality is available by adding instructional text in the search bar placeholder.

![CleanShot 2022-10-20 at 18 46 33@2x](https://user-images.githubusercontent.com/28797553/196940162-8a341af6-e26a-4c0c-9ab6-4a951ba297c2.png)

 

