### PR TITLE
Handle version expiry in the frontend

### DIFF
--- a/src/state/items.js
+++ b/src/state/items.js
@@ -7,6 +7,11 @@ export const isExpired = (item) => {
   if (item.expires === "never" || !item.expires) {
     return false;
   }
+  // Expiry can be by version. We can't check their expiry.
+  // Valid dates are in YYYY-MM-DD format.
+  if (item.expires.indexOf("-") == -1) {
+    return false;
+  }
   return new Date() > new Date(item.expires);
 };
 

--- a/tests/state.items.test.js
+++ b/tests/state.items.test.js
@@ -10,6 +10,9 @@ describe("checking if a date has expired", () => {
   it("returns False if input is a date from the future", () => {
     expect(isExpired({ expires: "3021-01-01" })).toBe(false);
   });
+  it("returns False if input does not look like a date (but a version)", () => {
+    expect(isExpired({ expires: "103" })).toBe(false);
+  });
 });
 
 describe("isRemoved works as expected", () => {


### PR DESCRIPTION
We check for a dash ("-") in the expiry, which indicates it's a date in YYYY-MM-DD format.
Not sure if this is the best way to fix it but it's _a_ way.

follow-up to #1499 to fix #1497 

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
