### PR TITLE
Fix displaying expiry information when expiry is a version number

### DIFF
--- a/etl/expiry.py
+++ b/etl/expiry.py
@@ -15,7 +15,7 @@ def get_expiry_text(expiry, app_name, product_details):
 
     if expiry == "never" or expiry is None:
         return expiry
-    elif app_name == "firefox_desktop":
+    if type(expiry) == int and (app_name in ["firefox_desktop", "fenix", "firefox_ios"]):
         return f"{expiry}. Latest release is \
      [{latest_release_version}](https://wiki.mozilla.org/Release_Management/Calendar)."
 

--- a/etl/expiry.py
+++ b/etl/expiry.py
@@ -16,6 +16,9 @@ def get_expiry_text(expiry, app_name, product_details):
     if expiry == "never" or expiry is None:
         return expiry
     if type(expiry) == int and (app_name in ["firefox_desktop", "fenix", "firefox_ios"]):
+        # We only have expiry versions for Firefox Desktop and Mobile currently.
+        # Let's update this when version-based expiry are available for other apps.
+        # See: https://github.com/mozilla/glean-dictionary/issues/1513
         return f"{expiry}. Latest release is \
      [{latest_release_version}](https://wiki.mozilla.org/Release_Management/Calendar)."
 

--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -127,6 +127,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
     annotations_index = requests.get(ANNOTATIONS_URL).json()
     looker_namespaces = yaml.safe_load(requests.get(NAMESPACES_URL).text)
     product_details = requests.get(FIREFOX_PRODUCT_DETAIL_URL).json()
+    latest_fx_release_version = list(product_details)[-1]
 
     # Then, get the apps we're using
     apps = [app for app in GleanApp.get_apps()]
@@ -315,6 +316,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                             description=metric.description,
                             tags=metric.tags,
                             in_source=metric.definition["in_source"],
+                            latest_fx_release_version=latest_fx_release_version,
                             extra_keys=metric.definition["extra_keys"]
                             if "extra_keys" in metric.definition
                             else None,
@@ -352,6 +354,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                                 repo_url=app.app["url"],
                                 variants=[],
                                 expires=base_definition["expires"],
+                                latest_fx_release_version=latest_fx_release_version,
                                 expiry_text=base_definition["expiry_text"],
                                 canonical_app_name=app.app["canonical_app_name"],
                                 app_tags=app_tags_for_app,

--- a/etl_tests/test_expiry.py
+++ b/etl_tests/test_expiry.py
@@ -12,14 +12,14 @@ def test_get_mapped_expiry(fake_product_details):
     assert get_mapped_expiry("1", "firefox_desktop", fake_product_details) == "2004-11-09"
     assert get_mapped_expiry("0", "firefox_desktop", fake_product_details) is None
     assert get_mapped_expiry("never", "fenix", fake_product_details) is None
-    assert get_mapped_expiry("97", "fenix", fake_product_details) == "97"
+    assert get_mapped_expiry(97, "fenix", fake_product_details) == 97
 
 
 def test_get_expiry_text(fake_product_details):
     assert get_expiry_text("never", "fenix", fake_product_details) == "never"
     assert get_expiry_text(None, "firefox_desktop", fake_product_details) is None
     assert (
-        get_expiry_text("0", "firefox_desktop", fake_product_details)
+        get_expiry_text(0, "firefox_desktop", fake_product_details)
         == "0. Latest release is \
      [1.0](https://wiki.mozilla.org/Release_Management/Calendar)."
     )

--- a/src/state/items.js
+++ b/src/state/items.js
@@ -7,6 +7,11 @@ export const isExpired = (item) => {
   if (item.expires === "never" || !item.expires) {
     return false;
   }
+  // if expires is a number, ie a version number, then compare it
+  // to the latest release version (only applied to Fx products)
+  if (!Number.isNaN(item.expires) && item.latest_fx_release_version) {
+    return Number(item.latest_fx_release_version) > item.expires;
+  }
   return new Date() > new Date(item.expires);
 };
 


### PR DESCRIPTION
The dictionary is marking some metrics as expired when they're not. For example, searching for `tracking_protection` metrics only yields one metric that is currently active, when there are at least 13 metrics that match the search term.

https://glean-dictionary-dev.netlify.app/apps/fenix?page=1&search=tracking_protection

<img width="854" alt="CleanShot 2022-11-14 at 07 56 15@2x" src="https://user-images.githubusercontent.com/28797553/201665805-e87900d9-34b1-43e7-8ef7-b56f6eed019a.png">

To fix this, we need to address the case when expiry information is a version number.

This PR includes:
- Get the latest release version from the product API
- Then, if the expiry is an integer, compare it to the latest release version to determine if it has expired.

Examples

Correctly showing all the metrics that have not expired: [link](http://deploy-preview-1512--glean-dictionary-dev.netlify.app/apps/fenix?page=1&search=tracking_protection)

<img width="954" alt="CleanShot 2022-11-14 at 08 12 27@2x" src="https://user-images.githubusercontent.com/28797553/201668922-a76d5d23-a112-44d2-b5a2-38235831134a.png">


On the metric page, the correct expiry info is shown: [link](http://deploy-preview-1512--glean-dictionary-dev.netlify.app/apps/fenix/metrics/preferences_etp_custom_cookies_selection)

![CleanShot 2022-11-14 at 08 12 44@2x](https://user-images.githubusercontent.com/28797553/201669002-e79c5157-036a-4c0e-a391-c7baa7d67466.png)

Fixes #1497.