### PR TITLE
Show expiration information with metric search

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -174,17 +174,22 @@
         <!-- We have to do inline styling here to override Protocol CSS rules -->
         <!-- https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity -->
         <col width="35%" />
-        <col
-          width={itemType === "metrics" || itemType === "tags" ? "20%" : "65%"}
-        />
-        <col
-          width={itemType === "metrics" || itemType === "tags" ? "45%" : "0"}
-        />
+        {#if itemType === "metrics"}
+          <col width="15%" />
+          <col width="15%" />
+          <col width="35%" />
+        {:else if itemType === "tags"}
+          <col width="20%" />
+          <col width="45%" />
+        {:else}
+          <col width="65%" />
+        {/if}
         <thead>
           <tr>
             <th scope="col" style="text-align: center;">Name</th>
             {#if itemType === "metrics"}
               <th scope="col" style="text-align: center;">Type</th>
+              <th scope="col" style="text-align: center;">Expiration</th>
             {:else if itemType === "tags"}
               <th scope="col" style="text-align: center;">Metric Count</th>
             {/if}
@@ -268,6 +273,11 @@
                 <td style="text-align: center;">
                   <div class="item-property">
                     <code>{@html highlightSearch(item.type, search)}</code>
+                  </div>
+                </td>
+                <td style="text-align: center;">
+                  <div class="item-property">
+                    {item.expires ? item.expires : "never"}
                   </div>
                 </td>
               {:else if itemType === "tags"}


### PR DESCRIPTION
Recently, in our internal Slack, some users asked to show the expiration information in the search view, rather than having it only on the MetricDetails page.

See the [deploy preview](https://deploy-preview-1517--glean-dictionary-dev.netlify.app/apps/fenix) for the UI change.

<img width="1554" alt="CleanShot 2022-11-17 at 10 04 15@2x" src="https://user-images.githubusercontent.com/28797553/202481957-31db5f2d-62f3-4cea-aa04-ed3eebe0cb23.png">

