### PR TITLE
Enable filtering by expiration information

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -277,7 +277,9 @@
                 </td>
                 <td style="text-align: center;">
                   <div class="item-property">
-                    {item.expires ? item.expires : "never"}
+                    <Markdown
+                      text={item.expires ? item.expiry_text : "never"}
+                    />
                   </div>
                 </td>
               {:else if itemType === "tags"}

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -144,7 +144,7 @@
   {#if showFilter}
     <FilterInput
       tooltipped={true}
-      placeHolder="To search by metric type, tag, or origin: use [type:], [tags:] , or [origin:]. Example: `type:event addons`, `tags:Sync account`"
+      placeHolder="To search by metric type, tag, origin, or expiration date: use [type:], [tags:], [origin:], [expires:<number of months/versions from now>]. Example: `type:event addons`, `tags:Sync account`, `expires:6`, `expires:never`"
     />
   {/if}
   {#if !filteredItems.length}

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -9,7 +9,7 @@ export const filterUncollectedItems = (items, showUncollected) =>
 export const filterItemsByLabels = (items, labels) => {
   let itemsFilteredByLabels = items;
   // we don't need to filter by "expires" in this method
-  let labelsToFilter = omit(labels, "expires");
+  const labelsToFilter = omit(labels, "expires");
   // filter items that match every value of a label type
   // (e.g. an item can have multiple tags)
   const getItemsByLabel = (label) =>
@@ -36,17 +36,19 @@ export const filterItemsByExpiration = (items, monthsOrVersionFromNow) => {
   // filter items that will expire by comparing the expiration date/version
   // to the target date/version in X months
   // the assumption is that there's a new version release every month
-  let today = new Date();
-  let targetDate = today.setMonth(
+  const today = new Date();
+  const targetDate = today.setMonth(
     today.getMonth() + Number(monthsOrVersionFromNow)
   );
-  const willExpireItems = items.filter((item) => item.expires);
 
-  let filteredByDate = willExpireItems.filter(
+  // don't include items that don't expire
+  const itemsWithAnExpirationDate = items.filter((item) => item.expires);
+
+  const filteredByDate = itemsWithAnExpirationDate.filter(
     (item) => Date.parse(item.expires) && new Date(item.expires) < targetDate
   );
 
-  let filteredByVersion = willExpireItems.filter(
+  const filteredByVersion = itemsWithAnExpirationDate.filter(
     (item) =>
       item.expires &&
       item.latest_fx_release_version &&

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -53,11 +53,11 @@ export const filterItemsByExpiration = (items, monthsOrVersionFromNow) => {
     const expirationVersion = Number(item.expires);
     if (Number.isNaN(expirationVersion)) {
       const expirationDate = Date.parse(item.expires);
-      return expirationDate < targetDate;
+      return expirationDate <= targetDate;
     }
 
     const targetVersion =
       Number(item.latest_fx_release_version) + Number(monthsOrVersionFromNow);
-    return expirationVersion < targetVersion;
+    return expirationVersion <= targetVersion;
   });
 };

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -39,14 +39,17 @@ export const filterItemsByExpiration = (items, monthsOrVersionFromNow) => {
   if (monthsOrVersionFromNow === "never") {
     return items.filter((item) => !item.expires || item.expires === "never");
   }
+
+  const itemsWithAnExpirationDate = items.filter(
+    (item) => item.expires || !item.expires === "never"
+  );
+
   const today = new Date();
   const targetDate = today.setMonth(
     today.getMonth() + Number(monthsOrVersionFromNow)
   );
 
-  return items.filter((item) => {
-    if (item.expires === "never") return false;
-
+  return itemsWithAnExpirationDate.filter((item) => {
     const expirationVersion = Number(item.expires);
     if (Number.isNaN(expirationVersion)) {
       const expirationDate = Date.parse(item.expires);

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -34,8 +34,11 @@ export const filterItemsByLabels = (items, labels) => {
 
 export const filterItemsByExpiration = (items, monthsOrVersionFromNow) => {
   // filter items that will expire by comparing the expiration date/version
-  // to the target date/version in X months
-  // the assumption is that there's a new version release every month
+  // to the target date/version in n = monthsOrVersionFromNow months
+  // the assumption is that there's a new version released every month
+  if (monthsOrVersionFromNow === "never") {
+    return items.filter((item) => !item.expires || item.expires === "never");
+  }
   const today = new Date();
   const targetDate = today.setMonth(
     today.getMonth() + Number(monthsOrVersionFromNow)
@@ -50,13 +53,11 @@ export const filterItemsByExpiration = (items, monthsOrVersionFromNow) => {
 
   const filteredByVersion = itemsWithAnExpirationDate.filter(
     (item) =>
-      item.expires &&
+      !Number.isNaN(item.expires) &&
       item.latest_fx_release_version &&
-      Number(item.expires) <=
+      item.expires <=
         Number(item.latest_fx_release_version) + Number(monthsOrVersionFromNow)
   );
-  if (monthsOrVersionFromNow === "never") {
-    return items.filter((item) => !item.expires);
-  }
+
   return [...filteredByDate, ...filteredByVersion];
 };

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -1,4 +1,4 @@
-import { intersection } from "lodash";
+import { intersection, omit } from "lodash";
 import { isExpired, isRemoved } from "./items";
 
 export const filterUncollectedItems = (items, showUncollected) =>
@@ -8,19 +8,21 @@ export const filterUncollectedItems = (items, showUncollected) =>
 
 export const filterItemsByLabels = (items, labels) => {
   let itemsFilteredByLabels = items;
-
+  // we don't need to filter by "expires" in this method
+  let labelsToFilter = omit(labels, "expires");
   // filter items that match every value of a label type
   // (e.g. an item can have multiple tags)
   const getItemsByLabel = (label) =>
     items.filter(
       (item) =>
-        item[label] && labels[label].every((el) => item[label].includes(el))
+        item[label] &&
+        labelsToFilter[label].every((el) => item[label].includes(el))
     );
 
   // for each label type, get an array of items that match all labels of that type
   // then, filter the result by getting the intersection of said arrays
-  Object.keys(labels).forEach((key) => {
-    if (labels[key].length) {
+  Object.keys(labelsToFilter).forEach((key) => {
+    if (labelsToFilter[key].length) {
       itemsFilteredByLabels = intersection(
         getItemsByLabel(key),
         itemsFilteredByLabels
@@ -28,4 +30,31 @@ export const filterItemsByLabels = (items, labels) => {
     }
   });
   return itemsFilteredByLabels;
+};
+
+export const filterItemsByExpiration = (items, monthsOrVersionFromNow) => {
+  // filter items that will expire by comparing the expiration date/version
+  // to the target date/version in X months
+  // the assumption is that there's a new version release every month
+  let today = new Date();
+  let targetDate = today.setMonth(
+    today.getMonth() + Number(monthsOrVersionFromNow)
+  );
+  const willExpireItems = items.filter((item) => item.expires);
+
+  let filteredByDate = willExpireItems.filter(
+    (item) => Date.parse(item.expires) && new Date(item.expires) < targetDate
+  );
+
+  let filteredByVersion = willExpireItems.filter(
+    (item) =>
+      item.expires &&
+      item.latest_fx_release_version &&
+      Number(item.expires) <=
+        Number(item.latest_fx_release_version) + Number(monthsOrVersionFromNow)
+  );
+  if (monthsOrVersionFromNow === "never") {
+    return items.filter((item) => !item.expires);
+  }
+  return [...filteredByDate, ...filteredByVersion];
 };

--- a/src/state/filter.js
+++ b/src/state/filter.js
@@ -44,20 +44,17 @@ export const filterItemsByExpiration = (items, monthsOrVersionFromNow) => {
     today.getMonth() + Number(monthsOrVersionFromNow)
   );
 
-  // don't include items that don't expire
-  const itemsWithAnExpirationDate = items.filter((item) => item.expires);
+  return items.filter((item) => {
+    if (item.expires === "never") return false;
 
-  const filteredByDate = itemsWithAnExpirationDate.filter(
-    (item) => Date.parse(item.expires) && new Date(item.expires) < targetDate
-  );
+    const expirationVersion = Number(item.expires);
+    if (Number.isNaN(expirationVersion)) {
+      const expirationDate = Date.parse(item.expires);
+      return expirationDate < targetDate;
+    }
 
-  const filteredByVersion = itemsWithAnExpirationDate.filter(
-    (item) =>
-      !Number.isNaN(item.expires) &&
-      item.latest_fx_release_version &&
-      item.expires <=
-        Number(item.latest_fx_release_version) + Number(monthsOrVersionFromNow)
-  );
-
-  return [...filteredByDate, ...filteredByVersion];
+    const targetVersion =
+      Number(item.latest_fx_release_version) + Number(monthsOrVersionFromNow);
+    return expirationVersion < targetVersion;
+  });
 };

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -74,11 +74,11 @@ const items = [
   },
   {
     name: "metric.meh",
-    expires: 129,
+    expires: 110,
     tags: [],
     origin: "sync",
     in_source: true,
-    latest_fx_release_version: 120,
+    latest_fx_release_version: 100,
   },
   {
     name: "metric.test",
@@ -114,7 +114,7 @@ describe("filter items by labels", () => {
 
 describe("filter items by expiration", () => {
   it("returns items that will expire in 6 versions/months", () =>
-    expect(getNames(filterItemsByExpiration(unCollectedMetrics, "6"))).toEqual([
+    expect(getNames(filterItemsByExpiration(unCollectedMetrics, 6))).toEqual([
       "metric.bestsitez",
       "metric.camel",
       "metric.blah",

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -7,8 +7,8 @@ import {
 const today = new Date();
 const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-const sixMonthsFromNow = dateObj.setMonth(today.getMonth() + 6);
-const twelveMonthsFromNow = dateObj.setMonth(today.getMonth() + 12);
+const sixMonthsFromNow = today.setMonth(today.getMonth() + 6);
+const twelveMonthsFromNow = today.setMonth(today.getMonth() + 12);
 
 function getDateStr(date) {
   return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
@@ -112,19 +112,19 @@ describe("filter items by labels", () => {
 
 describe("filter items by expiration", () => {
   it("returns items that will expire in 6 versions/months", () =>
-    expect(getNames(filterItemsByExpirationDate(items, 6))).toEqual([
+    expect(getNames(filterItemsByExpiration(items, 6))).toEqual([
       "metric.2",
       "metric.4",
     ]));
 
   it("returns items that will expire in 12 versions/months", () =>
-    expect(getNames(filterItemsByExpirationDate(items, 6))).toEqual([
+    expect(getNames(filterItemsByExpiration(items, 6))).toEqual([
       "metric.2",
       "metric.3",
       "metric.4",
     ]));
   it("returns items that never expire", () =>
-    expect(getNames(filterItemsByExpirationDate(items, "never"))).toEqual([
+    expect(getNames(filterItemsByExpiration(items, "never"))).toEqual([
       "metric.5",
     ]));
 });

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -1,11 +1,14 @@
 import {
   filterUncollectedItems,
   filterItemsByLabels,
+  filterItemsByExpiration,
 } from "../src/state/filter";
 
 const today = new Date();
 const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
+const sixMonthsFromNow = dateObj.setMonth(today.getMonth() + 6);
+const twelveMonthsFromNow = dateObj.setMonth(today.getMonth() + 12);
 
 function getDateStr(date) {
   return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
@@ -51,6 +54,43 @@ const items = [
     origin: "sync",
     in_source: false,
   },
+  {
+    name: "metric.1",
+    expires: 99,
+    tags: [],
+    latest_fx_release_version: 100,
+    in_source: false,
+  },
+  {
+    name: "metric.2",
+    expires: getDateStr(sixMonthsFromNow),
+    tags: [],
+    origin: "sync",
+    latest_fx_release_version: 100,
+    in_source: false,
+  },
+  {
+    name: "metric.3",
+    expires: getDateStr(twelveMonthsFromNow),
+    tags: [],
+    origin: "sync",
+    latest_fx_release_version: 100,
+    in_source: false,
+  },
+  {
+    name: "metric.4",
+    expires: 105,
+    tags: [],
+    origin: "sync",
+    in_source: false,
+  },
+  {
+    name: "metric.5",
+    expires: "never",
+    tags: [],
+    origin: "sync",
+    in_source: false,
+  },
 ];
 
 describe("expiry", () => {
@@ -67,5 +107,24 @@ describe("filter items by labels", () => {
     expect(getNames(filterItemsByLabels(items, labels))).toEqual([
       "metric.foo",
       "metric.baz",
+    ]));
+});
+
+describe("filter items by expiration", () => {
+  it("returns items that will expire in 6 versions/months", () =>
+    expect(getNames(filterItemsByExpirationDate(items, 6))).toEqual([
+      "metric.2",
+      "metric.4",
+    ]));
+
+  it("returns items that will expire in 12 versions/months", () =>
+    expect(getNames(filterItemsByExpirationDate(items, 6))).toEqual([
+      "metric.2",
+      "metric.3",
+      "metric.4",
+    ]));
+  it("returns items that never expire", () =>
+    expect(getNames(filterItemsByExpirationDate(items, "never"))).toEqual([
+      "metric.5",
     ]));
 });

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -7,11 +7,14 @@ import {
 const today = new Date();
 const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-const sixMonthsFromNow = today.setMonth(today.getMonth() + 6);
-const twelveMonthsFromNow = today.setMonth(today.getMonth() + 12);
+const fiveMonthsFromNow = new Date(today.getTime() + 24 * 60 * 60 * 150 * 1000);
+const elevenMonthsFromNow = today.setMonth(today.getMonth() + 11);
 
 function getDateStr(date) {
-  return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+  const newDate = new Date(date);
+  return `${newDate.getFullYear()}-${
+    newDate.getMonth() + 1
+  }-${newDate.getDate()}`;
 }
 
 function getNames(items) {
@@ -32,72 +35,71 @@ const items = [
     in_source: true,
   },
   { name: "metric.expired", expires: getDateStr(yesterday), in_source: true },
-  { name: "metric.removed", expires: getDateStr(tomorrow), in_source: false },
+  { name: "metric.removed", expires: getDateStr(yesterday), in_source: false },
   {
     name: "metric.foo",
-    expires: getDateStr(tomorrow),
+    expires: getDateStr(yesterday),
     origin: "sync",
     tags: ["Foo", "Bar"],
     in_source: false,
   },
   {
     name: "metric.bar",
-    expires: getDateStr(tomorrow),
+    expires: getDateStr(yesterday),
     tags: ["Foo"],
     origin: "sync",
     in_source: false,
   },
   {
     name: "metric.baz",
-    expires: getDateStr(tomorrow),
+    expires: getDateStr(yesterday),
     tags: ["Foo", "Bar", "Baz"],
     origin: "sync",
     in_source: false,
   },
   {
-    name: "metric.1",
-    expires: 99,
-    tags: [],
-    latest_fx_release_version: 100,
-    in_source: false,
-  },
-  {
-    name: "metric.2",
-    expires: getDateStr(sixMonthsFromNow),
+    name: "metric.blah",
+    expires: getDateStr(fiveMonthsFromNow),
     tags: [],
     origin: "sync",
-    latest_fx_release_version: 100,
-    in_source: false,
+    in_source: true,
   },
   {
-    name: "metric.3",
-    expires: getDateStr(twelveMonthsFromNow),
+    name: "metric.freh",
+    expires: getDateStr(elevenMonthsFromNow),
     tags: [],
     origin: "sync",
+    in_source: true,
     latest_fx_release_version: 100,
-    in_source: false,
   },
   {
-    name: "metric.4",
-    expires: 105,
+    name: "metric.meh",
+    expires: 129,
     tags: [],
     origin: "sync",
-    in_source: false,
+    in_source: true,
+    latest_fx_release_version: 120,
   },
   {
-    name: "metric.5",
+    name: "metric.test",
     expires: "never",
     tags: [],
     origin: "sync",
-    in_source: false,
+    in_source: true,
   },
 ];
 
+const unCollectedMetrics = filterUncollectedItems(items, false);
+
 describe("expiry", () => {
   it("doesn't return expired or removed items when showUncollected is false", () =>
-    expect(getNames(filterUncollectedItems(items, false))).toEqual([
+    expect(getNames(unCollectedMetrics)).toEqual([
       "metric.bestsitez",
       "metric.camel",
+      "metric.blah",
+      "metric.freh",
+      "metric.meh",
+      "metric.test",
     ]));
 });
 
@@ -112,19 +114,25 @@ describe("filter items by labels", () => {
 
 describe("filter items by expiration", () => {
   it("returns items that will expire in 6 versions/months", () =>
-    expect(getNames(filterItemsByExpiration(items, 6))).toEqual([
-      "metric.2",
-      "metric.4",
+    expect(getNames(filterItemsByExpiration(unCollectedMetrics, "6"))).toEqual([
+      "metric.bestsitez",
+      "metric.camel",
+      "metric.blah",
     ]));
 
   it("returns items that will expire in 12 versions/months", () =>
-    expect(getNames(filterItemsByExpiration(items, 6))).toEqual([
-      "metric.2",
-      "metric.3",
-      "metric.4",
-    ]));
+    expect(getNames(filterItemsByExpiration(unCollectedMetrics, "12"))).toEqual(
+      [
+        "metric.bestsitez",
+        "metric.camel",
+        "metric.blah",
+        "metric.freh",
+        "metric.meh",
+      ]
+    ));
+
   it("returns items that never expire", () =>
     expect(getNames(filterItemsByExpiration(items, "never"))).toEqual([
-      "metric.5",
+      "metric.test",
     ]));
 });

--- a/tests/state.filter.test.js
+++ b/tests/state.filter.test.js
@@ -7,8 +7,8 @@ import {
 const today = new Date();
 const yesterday = new Date(today.getTime() - 24 * 60 * 60 * 1000);
 const tomorrow = new Date(today.getTime() + 24 * 60 * 60 * 1000);
-const fiveMonthsFromNow = new Date(today.getTime() + 24 * 60 * 60 * 150 * 1000);
-const elevenMonthsFromNow = today.setMonth(today.getMonth() + 11);
+const sixMonthsFromNow = new Date(today.getTime() + 24 * 60 * 60 * 180 * 1000);
+const twelveMonthsFromNow = today.setMonth(today.getMonth() + 12);
 
 function getDateStr(date) {
   const newDate = new Date(date);
@@ -59,14 +59,14 @@ const items = [
   },
   {
     name: "metric.blah",
-    expires: getDateStr(fiveMonthsFromNow),
+    expires: getDateStr(sixMonthsFromNow),
     tags: [],
     origin: "sync",
     in_source: true,
   },
   {
     name: "metric.freh",
-    expires: getDateStr(elevenMonthsFromNow),
+    expires: getDateStr(twelveMonthsFromNow),
     tags: [],
     origin: "sync",
     in_source: true,


### PR DESCRIPTION
Let users search for metrics that will expire n number of months from now, by querying e.g. `expires:3` i.e. metrics that will expire 3 months/versions from now. 

Fixes #1467.
