### PR TITLE
Surface Fx legacy telemetry details (bucket, keyed, etc.)

### DIFF
--- a/etl/firefox_legacy_etl.py
+++ b/etl/firefox_legacy_etl.py
@@ -44,6 +44,7 @@ def _get_legacy_firefox_metric_summary(probe_data, activity_mapping):
             "type": probe["type"],
             "description": most_recent_metadata["description"],
             "bug_numbers": most_recent_metadata["bug_numbers"],
+            "details": most_recent_metadata["details"],
             "optout": most_recent_metadata["optout"],
             "kind": most_recent_metadata["details"]["kind"],
             "versions": {


### PR DESCRIPTION
In GLAM, the STMO dashboards we're building require parameters of bucket information: high, low, number of bucket, etc. Since GLAM is pulling metadata from the dictionary, so instead of making GLAM pull the `details` info from the probesinfo service separately, let's pull it to simplify the process.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
