### PR TITLE
Add suffix _date to name of datetime metrics

### DIFF
--- a/etl/looker.py
+++ b/etl/looker.py
@@ -201,7 +201,7 @@ def get_looker_explore_metadata_for_metric(
         elif metric_type in SUPPORTED_LOOKER_METRIC_TYPES:
             base_looker_dimension_name = "{}.{}".format(
                 ping_name_snakecase, get_bigquery_column_name(metric).replace(".", "__")
-            )
+            ) + ("_date" if metric_type == "datetime" else "")
             # For distribution types, we'll aggregate the sum of all distributions per
             # day. In most cases, this isn't super meaningful, but provides a starting
             # place for further analysis


### PR DESCRIPTION
Fixes #1637.

See deploy preview for correct linking to `datetime` metrics e.g. [background_update_targeting_env_profile_age ](https://deploy-preview-1655--glean-dictionary-dev.netlify.app/apps/firefox_desktop_background_update/metrics/background_update_targeting_env_profile_age)