### PR TITLE
Escape regex characters when doing a search (fixes #1664)

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { chunk } from "lodash";
+  import { chunk, escapeRegExp } from "lodash";
   import { Document } from "flexsearch";
 
   import { getItemURL } from "../state/urls";
@@ -66,7 +66,7 @@
   function highlightSearch(text, query) {
     return query.length
       ? text.replace(
-          new RegExp(query, "gi"),
+          new RegExp(escapeRegExp(query), "gi"),
           (match) => `<mark>${match}</mark>`
         )
       : text;


### PR DESCRIPTION
Currently search breaks if you use a regex character.
