### PR TITLE
Work around uBlock Origin privacy filters

### DIFF
--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -29,11 +29,20 @@ METRIC_CHANNEL_PRIORITY = {"nightly": 1, "beta": 2, "release": 3, "esr": 4}
 # Priority for sorting app ids in the UI (of anticipated relevance to the suer)
 USER_CHANNEL_PRIORITY = {"release": 1, "beta": 2, "nightly": 3, "esr": 4}
 
+# Certain words are blocked by uBlock Origin, so we need to map them to something else
+# to avoid the page being blocked
+# See: https://github.com/mozilla/glean-dictionary/issues/1682
+UBLOCK_ORIGIN_PRIVACY_FILTER = {"ad_impression": "advert_impression"}
+
 
 def _normalize_metrics(name):
     # replace . with _ so sirv doesn't think that
     # a metric is a file
     metric_name = name.replace(".", "_")
+
+    for key, value in UBLOCK_ORIGIN_PRIVACY_FILTER.items():
+        if key in metric_name:
+            metric_name = metric_name.replace(key, value)
 
     # if a metric name starts with "metrics", uBlock Origin
     # will block the network call to get the JSON resource

--- a/src/formatters/adblocker.js
+++ b/src/formatters/adblocker.js
@@ -1,0 +1,7 @@
+// Certain words are blocked by uBlock Origin, so we need to
+// map them to something else
+// See: https://github.com/mozilla/glean-dictionary/issues/1682
+
+export const UBLOCK_ORIGIN_PRIVACY_FILTER = {
+  ad_impression: "advert_impression",
+};

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -22,12 +22,10 @@ export async function getMetricData(appName, metricName) {
   let updatedMetricName = metricName;
 
   Object.keys(UBLOCK_ORIGIN_PRIVACY_FILTER).forEach((filter) => {
-    if (updatedMetricName.includes(filter)) {
-      updatedMetricName = updatedMetricName.replace(
-        filter,
-        UBLOCK_ORIGIN_PRIVACY_FILTER[filter]
-      );
-    }
+    updatedMetricName = updatedMetricName.replace(
+      filter,
+      UBLOCK_ORIGIN_PRIVACY_FILTER[filter]
+    );
   });
 
   // we added data to metric names to avoid the JSON resource

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -1,4 +1,5 @@
 import fetch from "node-fetch";
+import { UBLOCK_ORIGIN_PRIVACY_FILTER } from "../formatters/adblocker";
 
 export async function fetchJSON(uri) {
   const res = await fetch(uri);
@@ -20,7 +21,19 @@ export async function getPingData(appName, pingName) {
 export async function getMetricData(appName, metricName) {
   // we added data to metric names to avoid the JSON resource
   // calls being blocked by uBlock Origin
-  return fetchJSON(`/data/${appName}/metrics/data_${metricName}.json`);
+
+  Object.keys(UBLOCK_ORIGIN_PRIVACY_FILTER).forEach((filter) => {
+    if (metricName.includes(filter)) {
+      const newMetricName = metricName.replace(
+        filter,
+        UBLOCK_ORIGIN_PRIVACY_FILTER[filter]
+      );
+      console.log(newMetricName);
+      return fetchJSON(`/data/${appName}/metrics/data_${newMetricName}.json`);
+    } else return fetchJSON(`/data/${appName}/metrics/data_${metricName}.json`);
+  });
+  console.log("barb");
+  return;
 }
 
 export async function getTableData(appName, appId, pingName) {

--- a/src/state/api.js
+++ b/src/state/api.js
@@ -19,21 +19,20 @@ export async function getPingData(appName, pingName) {
 }
 
 export async function getMetricData(appName, metricName) {
-  // we added data to metric names to avoid the JSON resource
-  // calls being blocked by uBlock Origin
+  let updatedMetricName = metricName;
 
   Object.keys(UBLOCK_ORIGIN_PRIVACY_FILTER).forEach((filter) => {
-    if (metricName.includes(filter)) {
-      const newMetricName = metricName.replace(
+    if (updatedMetricName.includes(filter)) {
+      updatedMetricName = updatedMetricName.replace(
         filter,
         UBLOCK_ORIGIN_PRIVACY_FILTER[filter]
       );
-      console.log(newMetricName);
-      return fetchJSON(`/data/${appName}/metrics/data_${newMetricName}.json`);
-    } else return fetchJSON(`/data/${appName}/metrics/data_${metricName}.json`);
+    }
   });
-  console.log("barb");
-  return;
+
+  // we added data to metric names to avoid the JSON resource
+  // calls being blocked by uBlock Origin
+  return fetchJSON(`/data/${appName}/metrics/data_${updatedMetricName}.json`);
 }
 
 export async function getTableData(appName, appId, pingName) {


### PR DESCRIPTION
Fixes #1682.

See deploy preview to verify [serp_ad_impression](https://deploy-preview-1694--glean-dictionary-dev.netlify.app/apps/firefox_desktop/metrics/serp_ad_impression) is no longer blocked by uBlock Origin.