### PR TITLE
Handle missing `looker` property

### DIFF
--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -343,7 +343,7 @@
               href={getSTMOQueryURL(
                 metric.type,
                 selectedAppVariant.etl.bigquery_column_name,
-                pingData.looker.metric.name,
+                pingData.looker?.metric.name,
                 pingData.bigquery_table
               )}>STMO</a
             >


### PR DESCRIPTION
`pingData.looker` might be null, when there's no Looker explore we know about.
This in turn made this whole expression explode, because `e[3].looker is undefined`.
This results in a blank page, see e.g. any metric on the VPN app.

Instead we just pass on `undefined`. `getSTMOQueryURL` only needs that parameter for events and that code path already handles this value being falsy.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
