### PR TITLE
Link pings to Data Catalog

### DIFF
--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -137,7 +137,7 @@
       </td>
       <td>
         <AuthenticatedLink
-          href={`https://mozilla.acryl.io/dataset/urn:li:dataset:(urn:li:dataPlatform:bigquery,moz-fx-data-shared-prod.${selectedAppVariant.table},PROD)`}
+          href={`https://mozilla.acryl.io/dataset/urn:li:dataset:(urn:li:dataPlatform:Glean,${ping.origin}.${params.ping},PROD)`}
         >
           {selectedAppVariant.table}
         </AuthenticatedLink>

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -129,6 +129,19 @@
           </a>
         </td>
       </tr>
+      <td>
+        Data Catalog
+        <HelpHoverable
+          content={"View this table in Mozilla's instance of DataHub"}
+        />
+      </td>
+      <td>
+        <AuthenticatedLink
+          href={`https://mozilla.acryl.io/dataset/urn:li:dataset:(urn:li:dataPlatform:bigquery,moz-fx-data-shared-prod.${selectedAppVariant.table},PROD)`}
+        >
+          {selectedAppVariant.table}
+        </AuthenticatedLink>
+      </td>
       {#if selectedAppVariant.looker_explore}
         <tr>
           <td>

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -139,7 +139,7 @@
         <AuthenticatedLink
           href={`https://mozilla.acryl.io/dataset/urn:li:dataset:(urn:li:dataPlatform:Glean,${ping.origin}.${params.ping},PROD)`}
         >
-          {selectedAppVariant.table}
+          {ping.origin}.{params.ping}
         </AuthenticatedLink>
       </td>
       {#if selectedAppVariant.looker_explore}


### PR DESCRIPTION
Since metrics are not available in Data Catalog yet, let's start by linking to pings.

<img width="455" alt="CleanShot 2023-05-18 at 12 49 08@2x" src="https://github.com/mozilla/glean-dictionary/assets/28797553/7d0a39a0-326c-45b7-884f-303f10ba5843">


See the deploy preview of any ping pages: 
https://deploy-preview-1718--glean-dictionary-dev.netlify.app/apps/fenix?itemType=pings&page=1
