### PR TITLE
Expose all the UNION-ed tables

### DIFF
--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -320,6 +320,15 @@
                 selectedPingVariant.id
               )}>{pingData.bigquery_table}</a
             >
+            and <AuthenticatedLink
+              href={`https://mozilla.acryl.io/dataset/urn:li:dataset:(urn:li:dataPlatform:bigquery,moz-fx-data-shared-prod.${params.app}.${selectedPingVariant.id},PROD)`}
+            >
+              {params.app}.{selectedPingVariant.id}
+              <HelpHoverable
+                content={"The result table of UNION-ing all the per-app_id datasets."}
+                link={"https://github.com/mozilla/bigquery-etl/tree/main/sql_generators/glean_usage#glean-usage"}
+              />
+            </AuthenticatedLink>
             <!-- Skip search string for event metrics as we can't directly lookup the columns in events tables -->
             {#if metric.type !== "event"}
               as
@@ -342,19 +351,6 @@
                 >{metric.event_info.name}</code
               >
               <CopyButton textToCopy={metric.event_info.name} />)
-            {/if}
-            {#if metric.variants.length}
-              <p>
-                (also in <AuthenticatedLink
-                  href={`https://mozilla.acryl.io/dataset/urn:li:dataset:(urn:li:dataPlatform:bigquery,moz-fx-data-shared-prod.${params.app}.${selectedPingVariant.id},PROD)`}
-                >
-                  {params.app}.{selectedPingVariant.id}
-                </AuthenticatedLink> — the
-                <a
-                  href="https://github.com/mozilla/bigquery-etl/tree/main/sql_generators/glean_usage#glean-usage"
-                  >combination</a
-                > of all the results of the per-app_id datasets.)
-              </p>
             {/if}
           </div>
         </td>

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -343,6 +343,19 @@
               >
               <CopyButton textToCopy={metric.event_info.name} />)
             {/if}
+            {#if metric.variants.length}
+              <p>
+                (also in <AuthenticatedLink
+                  href={`https://mozilla.acryl.io/dataset/urn:li:dataset:(urn:li:dataPlatform:bigquery,moz-fx-data-shared-prod.${params.app}.${selectedPingVariant.id},PROD)`}
+                >
+                  {params.app}.{selectedPingVariant.id}
+                </AuthenticatedLink> — the
+                <a
+                  href="https://github.com/mozilla/bigquery-etl/tree/main/sql_generators/glean_usage#glean-usage"
+                  >combination</a
+                > of all the results of the per-app_id datasets.)
+              </p>
+            {/if}
           </div>
         </td>
       </tr>


### PR DESCRIPTION
Fixes #1479. If there's more than one app_id available, there's always a UNION table, so essentially all Glean apps have it. 

Since Data Catalog is available now, we should link to this table in Data Catalog.

![CleanShot 2023-05-23 at 10 40 09@2x](https://github.com/mozilla/glean-dictionary/assets/28797553/1a61a652-82f1-496d-b669-6e7f06c5b3fb)

