### PR TITLE
Fx Desktop: Only return a date if there's one, otherwise use expire data

### DIFF
--- a/etl/expiry.py
+++ b/etl/expiry.py
@@ -1,7 +1,9 @@
 def get_mapped_expiry(expiry, app_name, product_details):
     # For Desktop we can map expiry versions to dates.
     if app_name == "firefox_desktop":
-        return product_details.get(f"{expiry}.0")
+        details = product_details.get(f"{expiry}.0")
+        if details:
+            return details
 
     # Other's might be either a date, a version or "never"
     if expiry == "never":

--- a/etl_tests/test_expiry.py
+++ b/etl_tests/test_expiry.py
@@ -10,7 +10,7 @@ def fake_product_details():
 
 def test_get_mapped_expiry(fake_product_details):
     assert get_mapped_expiry("1", "firefox_desktop", fake_product_details) == "2004-11-09"
-    assert get_mapped_expiry("0", "firefox_desktop", fake_product_details) is None
+    assert get_mapped_expiry("0", "firefox_desktop", fake_product_details) == "0"
     assert get_mapped_expiry("never", "fenix", fake_product_details) is None
     assert get_mapped_expiry(97, "fenix", fake_product_details) == 97
 


### PR DESCRIPTION
The release history only contains information about releases that actually happened already.
For metrics expiring in the future we won't have a specific date. So we need to return the known value, so that the frontend actually renders something.

Fixes #1752

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
