### PR TITLE
Make sure expiry text always returns a string

### DIFF
--- a/etl/expiry.py
+++ b/etl/expiry.py
@@ -24,4 +24,4 @@ def get_expiry_text(expiry, app_name, product_details):
         return f"{expiry}. Latest release is \
      [{latest_release_version}](https://wiki.mozilla.org/Release_Management/Calendar)."
 
-    return expiry
+    return str(expiry)


### PR DESCRIPTION
Currently some pages are failing (eg [Android Focus](https://dictionary.telemetry.mozilla.org/apps/focus_android?page=2)) due to markdown component always expecting a string. But some of the text input includes expiry information, and it can be a number, which is an invalid input that will fail Markdown. Since this method is called `get_expiry_**text**` we should make sure it always returns a string.