### PR TITLE
FXA-7936 - Fix DNT check in Safari

### DIFF
--- a/src/telemetry/index.js
+++ b/src/telemetry/index.js
@@ -17,7 +17,8 @@ const isDNTEnabled =
   navigator.doNotTrack === "yes" ||
   navigator.doNotTrack === "1" ||
   navigator.msDoNotTrack === "1" ||
-  ("msTrackingProtectionEnabled" in window.external &&
+  (typeof window.external !== "undefined" &&
+    "msTrackingProtectionEnabled" in window.external &&
     window.external.msTrackingProtectionEnabled());
 
 /**


### PR DESCRIPTION
It was discovered in https://mozilla-hub.atlassian.net/browse/FXA-7936 that Glean Dictionary shows a blank page on iOS and in Safari on Mac.
It seems to be caused by `window.external` not being [available in Safari](https://developer.mozilla.org/en-US/docs/Web/API/Window/external#browser_compatibility). We need to check if it exists before calling it in order to not break the page load.

I have tested this locally and confirmed that the fix works.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
