### PR TITLE
Allow empty dependency

### DIFF
--- a/etl/glean.py
+++ b/etl/glean.py
@@ -235,14 +235,15 @@ class GleanApp(object):
             for key, metricdict in data.items()
         ]
         for dependency in self.get_dependencies():
-            dependency_metrics = _cache.get_json(
-                GleanApp.METRICS_URL_TEMPLATE.format(dependency["v1_name"])
-            )
-            # augment these dependency names with the library_name where they came from
-            metrics += [
-                (d[0], {**d[1], "origin": dependency["library_name"]})
-                for d in dependency_metrics.items()
-            ]
+            if "v1_name" in dependency:
+                dependency_metrics = _cache.get_json(
+                    GleanApp.METRICS_URL_TEMPLATE.format(dependency["v1_name"])
+                )
+                # augment these dependency names with the library_name where they came from
+                metrics += [
+                    (d[0], {**d[1], "origin": dependency["library_name"]})
+                    for d in dependency_metrics.items()
+                ]
 
         ping_names = set(self._get_ping_data().keys())
         processed = []
@@ -274,15 +275,16 @@ class GleanApp(object):
         )
 
         for dependency in self.get_dependencies():
-            dependency_pings = dict(
-                [
-                    (p[0], {**p[1], "origin": dependency["library_name"]})
-                    for p in _cache.get_json(
-                        GleanApp.PING_URL_TEMPLATE.format(dependency["v1_name"])
-                    ).items()
-                ]
-            )
-            ping_data.update(dependency_pings)
+            if "v1_name" in dependency:
+                dependency_pings = dict(
+                    [
+                        (p[0], {**p[1], "origin": dependency["library_name"]})
+                        for p in _cache.get_json(
+                            GleanApp.PING_URL_TEMPLATE.format(dependency["v1_name"])
+                        ).items()
+                    ]
+                )
+                ping_data.update(dependency_pings)
 
         return ping_data
 


### PR DESCRIPTION
Allow empty `dependency` field, since [`probe-scraper`](https://mozilla.github.io/probe-scraper/#tag/v2/operation/getAppListings) also allows it, as such a case is needed with e.g. `accounts-backend`.

<img width="640" alt="Screenshot 2023-08-31 at 12 44 52 PM" src="https://github.com/mozilla/glean-dictionary/assets/28797553/13ce5f46-1f5c-4dad-a25e-2d0145f44001">


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
