### PR TITLE
Bump gleanjs to v2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/plugin-transform-runtime": "7.19.6",
         "@babel/preset-env": "^7.20.2",
         "@mozilla-protocol/core": "^17.0.1",
-        "@mozilla/glean": "https://gitpkg.now.sh/mozilla/glean.js/glean?release-v2.0.0-alpha.0",
+        "@mozilla/glean": "2.0.2",
         "@playwright/test": "^1.36.1",
         "@rollup/plugin-commonjs": "24.1.0",
         "@rollup/plugin-node-resolve": "15.0.0",
@@ -6810,13 +6810,12 @@
       "dev": true
     },
     "node_modules/@mozilla/glean": {
-      "version": "2.0.0-alpha.0",
-      "resolved": "https://gitpkg.now.sh/mozilla/glean.js/glean?release-v2.0.0-alpha.0",
-      "integrity": "sha512-AvX1Hmv8IRrovQe75kS8FrvSzVW2lfqKHeL2jbE8t1NJjJxB4D/XMUdHYQGcfvmrXieOidpSwFgeJ53BlF9bjg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.2.tgz",
+      "integrity": "sha512-ggboBpkNUraL+e3q+UtUMZmJ2ETS60/tiudIzqx8W1sZPZHRqiYf6eN64/NWr9pf7GfIvHXFwaisscTE/9UhdA==",
       "dev": true,
-      "license": "MPL-2.0",
       "dependencies": {
-        "fflate": "^0.7.1",
+        "fflate": "^0.8.0",
         "jose": "^4.0.4",
         "tslib": "^2.3.1",
         "uuid": "^9.0.0"
@@ -21997,9 +21996,9 @@
       "dev": true
     },
     "node_modules/fflate": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
-      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg==",
       "dev": true
     },
     "node_modules/figgy-pudding": {
@@ -43560,11 +43559,12 @@
       "dev": true
     },
     "@mozilla/glean": {
-      "version": "https://gitpkg.now.sh/mozilla/glean.js/glean?release-v2.0.0-alpha.0",
-      "integrity": "sha512-AvX1Hmv8IRrovQe75kS8FrvSzVW2lfqKHeL2jbE8t1NJjJxB4D/XMUdHYQGcfvmrXieOidpSwFgeJ53BlF9bjg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mozilla/glean/-/glean-2.0.2.tgz",
+      "integrity": "sha512-ggboBpkNUraL+e3q+UtUMZmJ2ETS60/tiudIzqx8W1sZPZHRqiYf6eN64/NWr9pf7GfIvHXFwaisscTE/9UhdA==",
       "dev": true,
       "requires": {
-        "fflate": "^0.7.1",
+        "fflate": "^0.8.0",
         "jose": "^4.0.4",
         "tslib": "^2.3.1",
         "uuid": "^9.0.0"
@@ -55065,9 +55065,9 @@
       "dev": true
     },
     "fflate": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.3.tgz",
-      "integrity": "sha512-0Zz1jOzJWERhyhsimS54VTqOteCNwRtIlh8isdL0AXLo0g7xNTfTL7oWrkmCnPhZGocKIkWHBistBrrpoNH3aw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.0.tgz",
+      "integrity": "sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg==",
       "dev": true
     },
     "figgy-pudding": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@babel/plugin-transform-runtime": "7.19.6",
     "@babel/preset-env": "^7.20.2",
     "@mozilla-protocol/core": "^17.0.1",
-    "@mozilla/glean": "https://gitpkg.now.sh/mozilla/glean.js/glean?release-v2.0.0-alpha.0",
+    "@mozilla/glean": "^2.0.2",
     "@playwright/test": "^1.36.1",
     "@rollup/plugin-commonjs": "24.1.0",
     "@rollup/plugin-node-resolve": "15.0.0",


### PR DESCRIPTION
Glean Dictionary was using an alpha release of Glean.js v2.0.0. This updates the dependency to use the newest version of the package, `v2.0.2`.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
