### PR TITLE
Enable showing only app metrics

### DIFF
--- a/src/components/AdjustDataTypes.svelte
+++ b/src/components/AdjustDataTypes.svelte
@@ -1,0 +1,11 @@
+<script context="module">
+  export const adjustDataTypes = {
+    // used for label description
+    Advertising: "Information about Advertising",
+    Installation: "Information about how the application was installed",
+    Application:
+      "Information about the version and build of the application and its bundle ID",
+    Device: "Information about the make and model of your device",
+    User: "Information about the user",
+  };
+</script>

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -21,7 +21,7 @@
     getLibraryDescription,
   } from "../data/help";
 
-  import { adjustDataTypes } from "./iOSThirdPartyData.svelte";
+  import { adjustDataTypes } from "./AdjustDataTypes.svelte";
 
   import { fullTextSearch } from "../state/search";
 

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -91,9 +91,9 @@
     totalItems = filteredItems.length;
 
     // filter out metrics that do not belong to the application
-    filteredItems = showAppMetricsOnly ? filteredItems.filter(
-      (item) => !item.origin
-    ) : filteredItems
+    filteredItems = showAppMetricsOnly
+      ? filteredItems.filter((item) => !item.origin)
+      : filteredItems;
 
     // now filter for uncollected items (if applicable)
     filteredItems = showUncollected

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -37,6 +37,7 @@
   let filteredItems = items.filter((item) => !isExpired(item));
   let pagedItems;
   let paginated = true;
+  let showAppMetricsOnly = false;
   let search;
   let showUncollected;
   let topElement;
@@ -89,6 +90,11 @@
     filteredItems = search ? fullTextSearch(search, items) : items;
     totalItems = filteredItems.length;
 
+    // filter out metrics that do not belong to the application
+    filteredItems = showAppMetricsOnly ? filteredItems.filter(
+      (item) => !item.origin
+    ) : filteredItems
+
     // now filter for uncollected items (if applicable)
     filteredItems = showUncollected
       ? filteredItems
@@ -124,6 +130,10 @@
   {#if itemType === "metrics"}
     <span class="expire-checkbox">
       <label>
+        <input type="checkbox" bind:checked={showAppMetricsOnly} />
+        Only show app metrics
+      </label>
+      <label>
         <input
           type="checkbox"
           bind:checked={showUncollected}
@@ -155,7 +165,7 @@
       </h3>
       {#if totalItems > 0}
         <p>
-          {totalItems} expired or removed {itemType} found.
+          {totalItems} expired, removed or hidden {itemType} found.
         </p>
         <button
           class="mzp-c-button mzp-t-secondary mzp-t-md"

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -315,8 +315,8 @@
     {#if totalItems - filteredItems.length > 0}
       <div class="items-not-found">
         <p>
-          {totalItems - filteredItems.length} additional expired or removed {itemType}
-          found.
+          {totalItems - filteredItems.length} additional expired, removed or hidden
+          {itemType} found.
         </p>
       </div>
     {/if}

--- a/src/components/iOSThirdPartyData.svelte
+++ b/src/components/iOSThirdPartyData.svelte
@@ -1,15 +1,3 @@
-<script context="module">
-  export const adjustDataTypes = {
-    // used for label description
-    Advertising: "Information about Advertising",
-    Installation: "Information about how the application was installed",
-    Application:
-      "Information about the version and build of the application and its bundle ID",
-    Device: "Information about the make and model of your device",
-    User: "Information about the user",
-  };
-</script>
-
 <script>
   import ItemList from "./ItemList.svelte";
 


### PR DESCRIPTION
This fixes #1944 .

It additionally breaks a circular dependency  detected at build time.

By ticking the box the Glean Dictionary entry shows this instead of two pages of less interesting metrics:

![immagine](https://github.com/mozilla/glean-dictionary/assets/883721/8f5a7646-1e04-4127-a8ca-0832484be610)


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
