### PR TITLE
Fix channel filter in looker links

### DIFF
--- a/etl/looker.py
+++ b/etl/looker.py
@@ -31,15 +31,14 @@ def _looker_explore_exists(looker_namespaces, app_name, explore_name):
 
 
 def _get_looker_ping_explore(
-    looker_namespaces, app_name, ping_name, table_name, app_channel, app_group
+    looker_namespaces, app_name, ping_name, _table_name, app_channel, app_group
 ):
     ping_name_snakecase = stringcase.snakecase(ping_name)
     if _looker_explore_exists(looker_namespaces, app_name, ping_name_snakecase):
         url = furl(f"https://mozilla.cloud.looker.com/explore/{app_name}/{ping_name_snakecase}")
         # if there are multiple channels, we need a channel identifier
         if len(app_group["app_ids"]) > 1 and app_channel:
-            channel_identifier = "mozdata." + table_name.replace("_", "^_")
-            url = url.add({f"f[{ping_name_snakecase}.channel]": channel_identifier})
+            url = url.add({f"f[{ping_name_snakecase}.channel]": app_channel})
         return {"name": ping_name_snakecase, "url": url.url}
     return None
 

--- a/etl_tests/test_looker.py
+++ b/etl_tests/test_looker.py
@@ -86,7 +86,7 @@ def test_get_looker_explore_metadata_for_timespan_metric(
 def test_get_looker_explore_metadata_for_metric_unioned_app(
     fake_namespaces, fake_app, fake_ping, fake_timespan_metric
 ):
-    # The application needs an "app channel" to trigger thie relevant
+    # The application needs an "app channel" to trigger the relevant
     # code path.
     fake_app.app["app_channel"] = "nightly"
 

--- a/etl_tests/test_looker.py
+++ b/etl_tests/test_looker.py
@@ -81,3 +81,44 @@ def test_get_looker_explore_metadata_for_timespan_metric(
             "url": "https://mozilla.cloud.looker.com/explore/fenix/metrics?fields=metrics.submission_date%2Cmedian_of_mytimespan&dynamic_fields=%5B%7B%22measure%22%3A+%22median_of_mytimespan%22%2C+%22label%22%3A+%22Median+of+mytimespan%22%2C+%22based_on%22%3A+%22metrics.metrics__timespan__mytimespan__value%22%2C+%22expression%22%3A+%22%22%2C+%22type%22%3A+%22median%22%7D%5D&toggle=vis",  # noqa
         },
     }
+
+
+def test_get_looker_explore_metadata_for_metric_unioned_app(
+    fake_namespaces, fake_app, fake_ping, fake_timespan_metric
+):
+    # The application needs an "app channel" to trigger thie relevant
+    # code path.
+    fake_app.app["app_channel"] = "nightly"
+
+    FAKE_APP_GROUP = {
+        "app_description": "Fenix for iOS",
+        "app_ids": [
+            {
+                "channel": "nightly",
+                "name": "org.mozilla.ios.Fennec",
+            },
+            {
+                "channel": "release",
+                "name": "org.mozilla.ios.Firefox",
+            },
+        ],
+        "app_name": "fenix",
+    }
+
+    assert get_looker_explore_metadata_for_metric(
+        fake_namespaces,
+        fake_app,
+        FAKE_APP_GROUP,
+        fake_timespan_metric,
+        fake_ping.identifier,
+        False,
+    ) == {
+        "base": {
+            "name": "metrics",
+            "url": "https://mozilla.cloud.looker.com/explore/fenix/metrics?f%5Bmetrics.channel%5D=nightly",  # noqa
+        },
+        "metric": {
+            "name": "mytimespan",
+            "url": "https://mozilla.cloud.looker.com/explore/fenix/metrics?f%5Bmetrics.channel%5D=nightly&fields=metrics.submission_date%2Cmedian_of_mytimespan&dynamic_fields=%5B%7B%22measure%22%3A+%22median_of_mytimespan%22%2C+%22label%22%3A+%22Median+of+mytimespan%22%2C+%22based_on%22%3A+%22metrics.metrics__timespan__mytimespan__value%22%2C+%22expression%22%3A+%22%22%2C+%22type%22%3A+%22median%22%7D%5D&toggle=vis",  # noqa
+        },
+    }


### PR DESCRIPTION
Fixes #1802 (hopefully?)

Use normalized filters instead of app ids as channels when dealing with grouped applications (unioned).
The normalized channel field used not to work in these cases, but that was recently fixed.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
