### PR TITLE
Add link to Looker event monitoring dashboard

### DIFF
--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -8,7 +8,11 @@ from .bigquery import get_bigquery_column_name, get_bigquery_ping_table_name
 from .expiry import get_expiry_text, get_mapped_expiry
 from .glam import SUPPORTED_GLAM_METRIC_TYPES, get_glam_metadata_for_metric
 from .glean import GleanApp
-from .looker import get_looker_explore_metadata_for_metric, get_looker_explore_metadata_for_ping
+from .looker import (
+    get_looker_explore_metadata_for_metric,
+    get_looker_explore_metadata_for_ping,
+    get_looker_monitoring_metadata_for_event,
+)
 from .search import create_metrics_search_js
 from .utils import dump_json, get_event_name_and_category
 
@@ -411,6 +415,12 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                         ping_data[ping_name].update({"looker": looker_metadata})
                     glam_metadata = get_glam_metadata_for_metric(app, metric, ping_name)
                     ping_data[ping_name].update(glam_metadata)
+
+                    event_monitoring_metadata = get_looker_monitoring_metadata_for_event(
+                        app, app_group, metric, ping_name
+                    )
+                    if event_monitoring_metadata:
+                        ping_data[ping_name].update({"event_monitoring": event_monitoring_metadata})
 
                 etl = dict(
                     ping_data=ping_data,

--- a/etl/looker.py
+++ b/etl/looker.py
@@ -284,7 +284,6 @@ def get_looker_monitoring_metadata_for_event(app, app_group, metric, ping_name):
         url.add({"Channel": app_channel})
 
     return {
-        "base": EVENT_MONITORING_DASHBOARD_URL,
         "event": {
             "name": metric_name,
             "url": url.url,

--- a/etl/looker.py
+++ b/etl/looker.py
@@ -20,6 +20,7 @@ SUPPORTED_LOOKER_METRIC_TYPES = GLEAN_DISTRIBUTION_TYPES | {
     "timespan",
     "uuid",
 }
+EVENT_MONITORING_DASHBOARD_URL = "https://mozilla.cloud.looker.com/dashboards/1452"
 
 
 def _looker_explore_exists(looker_namespaces, app_name, explore_name):
@@ -262,3 +263,30 @@ def get_looker_explore_metadata_for_metric(
             }
 
     return None
+
+
+def get_looker_monitoring_metadata_for_event(app, app_group, metric, ping_name):
+    if ping_name != "events":
+        return None
+
+    metric_type = metric.definition["type"]
+    if metric_type != "event":
+        return None
+
+    (_, metric_name) = get_event_name_and_category(metric.identifier)
+
+    url = furl(EVENT_MONITORING_DASHBOARD_URL).add(
+        {"App Name": app.app["canonical_app_name"], "Event Name": metric_name}
+    )
+
+    app_channel = app.app.get("app_channel")
+    if len(app_group["app_ids"]) > 1 and app_channel:
+        url.add({"Channel": app_channel})
+
+    return {
+        "base": EVENT_MONITORING_DASHBOARD_URL,
+        "event": {
+            "name": metric_name,
+            "url": url.url,
+        },
+    }

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -381,6 +381,28 @@
           />
         </td>
       </tr>
+      {#if pingData.event_monitoring}
+        <tr>
+          <td
+            >Monitoring <HelpHoverable
+              content={"Show real-time monitoring for this event in Mozilla's instance of Looker."}
+            />
+          </td>
+          <td>
+            <div>
+              In the
+              <AuthenticatedLink href={pingData.event_monitoring.base}>
+                Event Monitoring Dashboard
+              </AuthenticatedLink>
+              for the
+              <AuthenticatedLink href={pingData.event_monitoring.event.url}>
+                {pingData.event_monitoring.event.name}
+              </AuthenticatedLink>
+              event
+            </div>
+          </td>
+        </tr>
+      {/if}
     </table>
   {/if}
 {:catch}

--- a/src/pages/MetricDetail.svelte
+++ b/src/pages/MetricDetail.svelte
@@ -281,13 +281,11 @@
               content={"Explore this metric in Mozilla's instance of Looker."}
             />
           </td>
-          {#if metric.send_in_pings.length === 1 && metric.send_in_pings[0] === "events" && metric.type !== "event"}
-            <td
-              >This metric is a <code>{metric.type}</code> metric. Currently,
-              event count explores only support <code>event</code> metrics.</td
-            >
-          {:else}
-            <td>
+          <td>
+            {#if metric.send_in_pings.length === 1 && metric.send_in_pings[0] === "events" && metric.type !== "event"}
+              This metric is a <code>{metric.type}</code> metric. Currently,
+              event count explores only support <code>event</code> metrics.
+            {:else}
               <div>
                 In
                 <AuthenticatedLink href={pingData.looker.base.url}>
@@ -298,8 +296,18 @@
                   {pingData.looker.metric.name}
                 </AuthenticatedLink>
               </div>
-            </td>
-          {/if}
+            {/if}
+            {#if pingData.event_monitoring}
+              <div>
+                On the
+                <AuthenticatedLink href={pingData.event_monitoring.event.url}>
+                  Event Monitoring Dashboard for the
+                  {pingData.event_monitoring.event.name}
+                </AuthenticatedLink>
+                event
+              </div>
+            {/if}
+          </td>
         </tr>
       {/if}
       <tr>
@@ -381,28 +389,6 @@
           />
         </td>
       </tr>
-      {#if pingData.event_monitoring}
-        <tr>
-          <td
-            >Monitoring <HelpHoverable
-              content={"Show real-time monitoring for this event in Mozilla's instance of Looker."}
-            />
-          </td>
-          <td>
-            <div>
-              In the
-              <AuthenticatedLink href={pingData.event_monitoring.base}>
-                Event Monitoring Dashboard
-              </AuthenticatedLink>
-              for the
-              <AuthenticatedLink href={pingData.event_monitoring.event.url}>
-                {pingData.event_monitoring.event.name}
-              </AuthenticatedLink>
-              event
-            </div>
-          </td>
-        </tr>
-      {/if}
     </table>
   {/if}
 {:catch}


### PR DESCRIPTION
This adds a link to the [event monitoring dashboard](https://mozilla.cloud.looker.com/dashboards/1452?Event+Name=disqualification&App+Name=Firefox+for+iOS&Window+Start+Time=28+days&Channel=release) for Glean events.

cc @Dexterp37 
