### PR TITLE
Improve how we show sample rate information

### DIFF
--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -386,7 +386,6 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
 
                     if is_sampled:
                         for channel in metric_sample_info:
-                            sampled_text = "Not sampled"
                             sampled_text = (
                                 str(metric_sample_info.get(channel)["sample_size"] * 100)
                                 + "% "


### PR DESCRIPTION
Fixes #2020. 

Main changes:

- since most metrics are not currently being sampled, instead of showing the sampled column by default, this PR adds a checkbox to filter them instead
- add a tooltipped description to the sampling text
- persist the state in the URL for more accessible link sharing, eg: https://deploy-preview-2043--glean-dictionary-dev.netlify.app/apps/firefox_desktop?showSampled=1



![2023-12-04 14 52 54](https://github.com/mozilla/glean-dictionary/assets/28797553/e2dc30d8-09b0-42eb-bef0-6047e478f733)


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
