### PR TITLE
Fix quotes in Events dashboard links

### DIFF
--- a/etl/looker.py
+++ b/etl/looker.py
@@ -273,10 +273,11 @@ def get_looker_monitoring_metadata_for_event(app, app_group, metric, ping_name):
     if metric_type != "event":
         return None
 
-    (_, metric_name) = get_event_name_and_category(metric.identifier)
+    (metric_category, metric_name) = get_event_name_and_category(metric.identifier)
+    event_identifier = ".".join([metric_category, metric_name])
 
     url = furl(EVENT_MONITORING_DASHBOARD_URL).add(
-        {"App Name": app.app["canonical_app_name"], "Event Name": '"' + metric_name + '"'}
+        {"App Name": app.app["canonical_app_name"], "Event Name": '"' + event_identifier + '"'}
     )
 
     app_channel = app.app.get("app_channel")

--- a/etl/looker.py
+++ b/etl/looker.py
@@ -276,7 +276,7 @@ def get_looker_monitoring_metadata_for_event(app, app_group, metric, ping_name):
     (_, metric_name) = get_event_name_and_category(metric.identifier)
 
     url = furl(EVENT_MONITORING_DASHBOARD_URL).add(
-        {"App Name": app.app["canonical_app_name"], "Event Name": metric_name}
+        {"App Name": app.app["canonical_app_name"], "Event Name": '"' + metric_name + '"'}
     )
 
     app_channel = app.app.get("app_channel")


### PR DESCRIPTION
The event names need to be wrapped in quotes for the Looker filter to consider it as string and not raw value. 
