### PR TITLE
Add a header anchor link to every header rendered from commentary

### DIFF
--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -13,6 +13,15 @@
         start ? `start="${start}"` : ""
       } class="mzp-u-list-styled">${body}</${outerEl}>`;
     },
+    heading(text, level, raw) {
+      const id = raw
+        .toLowerCase()
+        .trim()
+        .replace(/<[!/a-z].*?>/gi, "")
+        .replace(/ +/g, "-");
+
+      return `<h${level} class="annotation-header-link" id="${id}"><a href="#${id}">${text}</a></h${level}>\n`;
+    },
   };
   use({ renderer });
 

--- a/src/components/Markdown.svelte
+++ b/src/components/Markdown.svelte
@@ -33,5 +33,26 @@
 {#if inline}
   {@html parseInline(text)}
 {:else}
-  {@html parse(text)}
+  <div>
+    {@html parse(text)}
+  </div>
 {/if}
+
+<style lang="scss">
+  div :global(h1 a),
+  div :global(h2 a),
+  div :global(h3 a),
+  div :global(h4 a),
+  div :global(h5 a) {
+    color: black;
+    text-decoration: none;
+  }
+
+  div :global(h1 a:hover),
+  div :global(h2 a:hover),
+  div :global(h3 a:hover),
+  div :global(h4 a:hover),
+  div :global(h5 a:hover) {
+    text-decoration: underline;
+  }
+</style>


### PR DESCRIPTION
Fixes https://github.com/mozilla/glean-annotations/issues/217

Completely unstyled for now, because I have no idea how to actually apply styling here.
I tried inline `<style>` but nothing seems to work.
Probably should make the headings black and underlined on hover.

cc @aminomancer 

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
