### PR TITLE
Allow search results to be filtered by name only

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -172,7 +172,7 @@
   {#if showFilter}
     <FilterInput
       tooltipped={true}
-      placeHolder="To search by metric type, tag, origin, or expiration date: use [type:], [tags:], [origin:], [expires:<number of months/versions from now>]. Example: `type:event addons`, `tags:Sync account`, `expires:6`, `expires:never`"
+      placeHolder="To search by metric name, type, tag, origin, or expiration date: use [name:], [type:], [tags:], [origin:], [expires:<number of months/versions from now>]. Example: `type:event addons`, `tags:Sync account`, `expires:6`, `expires:never`"
     />
   {/if}
   {#if !filteredItems.length}

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -27,7 +27,7 @@ export const fullTextSearch = (query, searchItems) => {
   let unlabeledsearchTerms = [];
 
   const searchTerms = query.match(/(?:(?:tags:)?".+")|"?[^ ]+"?/g);
-  const labels = { tags: [], origin: [], type: [], expires: [] };
+  const labels = { tags: [], origin: [], type: [], expires: [], name: [] };
   const searchIndex = generateSearchIndex(searchItems);
 
   searchTerms.forEach((term) => {
@@ -35,7 +35,8 @@ export const fullTextSearch = (query, searchItems) => {
       term.startsWith("tags:") ||
       term.startsWith("origin:") ||
       term.startsWith("type:") ||
-      term.startsWith("expires:")
+      term.startsWith("expires:") ||
+      term.startsWith("name:")
     ) {
       const splitter = term.indexOf(":");
       const labelType = term.slice(0, splitter);
@@ -54,6 +55,12 @@ export const fullTextSearch = (query, searchItems) => {
     itemsFilteredByLabels = filterItemsByExpiration(
       itemsFilteredByLabels,
       labels.expires[0]
+    );
+  }
+
+  if (labels.name.length) {
+    itemsFilteredByLabels = itemsFilteredByLabels.filter((item) =>
+      item.name.includes(labels.name[0])
     );
   }
 


### PR DESCRIPTION
Fixes #2113.

This PR introduces a new search filter that allows searching by names only. For example searching `name:browser.search.` will return only these results.

https://deploy-preview-2114--glean-dictionary-dev.netlify.app/apps/fenix?page=1&search=name%3Abrowser.search

![CleanShot 2024-02-05 at 13 17 11@2x](https://github.com/mozilla/glean-dictionary/assets/28797553/78703f01-bda3-405e-9fe7-91baa6641656)


### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
