### PR TITLE
[Bug 1883593] Capture app clicks via Glean's automated click events

### DIFF
--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -91,6 +91,10 @@
               id="media-wrapper"
               style="pointer-events:none"
             >
+              <!-- Setting style attribute is required above to allow capturing clicks on all nested elements
+                via Glean. Once https://bugzilla.mozilla.org/show_bug.cgi?id=1885504 is fixed it can be removed
+                from div tag above.
+              -->
               <img
                 class="mzp-c-card-imgage"
                 src={app.logo || "/img/app-logos/mozilla.png"}
@@ -107,6 +111,10 @@
               {/if}
             </div>
             <div class="mzp-c-card-content" style="pointer-events:none">
+              <!-- Setting style attribute is required above to allow capturing clicks on all nested elements
+                via Glean. Once https://bugzilla.mozilla.org/show_bug.cgi?id=1885504 is fixed it can be removed
+                from div tag above.
+              -->
               <h2 class="mzp-c-card-title">{app.canonical_app_name}</h2>
               {#if app.deprecated}
                 <Label text="deprecated" />

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -84,7 +84,7 @@
             class="mzp-c-card-block-link"
             href="/apps/{app.app_name}"
             id="media-block"
-            data-glean-label="Applist: {app.app_name}"
+            data-glean-label="Home page: {app.app_name}"
           >
             <div class="mzp-c-card-media-wrapper" id="media-wrapper" style="pointer-events:none">
               <img

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -84,8 +84,9 @@
             class="mzp-c-card-block-link"
             href="/apps/{app.app_name}"
             id="media-block"
+            data-glean-label="Applist: {app.app_name}"
           >
-            <div class="mzp-c-card-media-wrapper" id="media-wrapper">
+            <div class="mzp-c-card-media-wrapper" id="media-wrapper" style="pointer-events:none">
               <img
                 class="mzp-c-card-imgage"
                 src={app.logo || "/img/app-logos/mozilla.png"}
@@ -101,7 +102,7 @@
                 />
               {/if}
             </div>
-            <div class="mzp-c-card-content">
+            <div class="mzp-c-card-content" style="pointer-events:none">
               <h2 class="mzp-c-card-title">{app.canonical_app_name}</h2>
               {#if app.deprecated}
                 <Label text="deprecated" />

--- a/src/pages/AppList.svelte
+++ b/src/pages/AppList.svelte
@@ -86,7 +86,11 @@
             id="media-block"
             data-glean-label="Home page: {app.app_name}"
           >
-            <div class="mzp-c-card-media-wrapper" id="media-wrapper" style="pointer-events:none">
+            <div
+              class="mzp-c-card-media-wrapper"
+              id="media-wrapper"
+              style="pointer-events:none"
+            >
               <img
                 class="mzp-c-card-imgage"
                 src={app.logo || "/img/app-logos/mozilla.png"}

--- a/src/telemetry/index.js
+++ b/src/telemetry/index.js
@@ -41,6 +41,7 @@ export function initializeTelemetry() {
   Glean.initialize("__GLEAN_APPLICATION_ID__", !isDNTEnabled, {
     appBuild: "__VERSION__",
     appDisplayVersion: "__DISPLAY_VERSION__",
+    enableAutoElementClickEvents:true
   });
 
   /* eslint-disable no-undef, no-constant-condition */

--- a/src/telemetry/index.js
+++ b/src/telemetry/index.js
@@ -41,7 +41,7 @@ export function initializeTelemetry() {
   Glean.initialize("__GLEAN_APPLICATION_ID__", !isDNTEnabled, {
     appBuild: "__VERSION__",
     appDisplayVersion: "__DISPLAY_VERSION__",
-    enableAutoElementClickEvents:true
+    enableAutoElementClickEvents: true,
   });
 
   /* eslint-disable no-undef, no-constant-condition */


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1883593#c1

1. This PR adds the capability to capture clicks when a user cliks on various apps listed on the home page of Glean Dictionary using Glean's automated click capturing feature (as per https://bugzilla.mozilla.org/show_bug.cgi?id=1883593#c1)
2. The rest of the click event capturing will be done after https://bugzilla.mozilla.org/show_bug.cgi?id=1885504 is resolved.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->