### PR TITLE
[DENG-3417] Show link to Looker event monitoring dashboard for all metrics with type=event

### DIFF
--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -496,7 +496,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                     ping_data[ping_name].update(glam_metadata)
 
                     event_monitoring_metadata = get_looker_monitoring_metadata_for_event(
-                        app, app_group, metric, ping_name
+                        app, app_group, metric
                     )
                     if event_monitoring_metadata:
                         ping_data[ping_name].update({"event_monitoring": event_monitoring_metadata})

--- a/etl/looker.py
+++ b/etl/looker.py
@@ -265,10 +265,7 @@ def get_looker_explore_metadata_for_metric(
     return None
 
 
-def get_looker_monitoring_metadata_for_event(app, app_group, metric, ping_name):
-    if ping_name != "events":
-        return None
-
+def get_looker_monitoring_metadata_for_event(app, app_group, metric):
     metric_type = metric.definition["type"]
     if metric_type != "event":
         return None


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/DENG-3417

We want to show links to the event monitoring dashboards for all metrics with type event, not just for those coming from the event ping.

