### PR TITLE
2248: Fix search path for application-services hosted libs

### DIFF
--- a/src/components/MetadataTable.svelte
+++ b/src/components/MetadataTable.svelte
@@ -8,7 +8,7 @@
   export let item = {};
 
   function format(ref, formatter) {
-    return formatter ? formatter(ref, appName) : ref;
+    return formatter ? formatter(ref, appName, item) : ref;
   }
 </script>
 

--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -78,7 +78,7 @@ export const METRIC_DEFINITION_SCHEMA = [
     type: "link",
     helpText:
       "Finds uses of this metric using simple matching. Metrics used dynamically may not appear in the results, only metrics defined in the application will be found.",
-    linkFormatter: (metricId, appName) => getCodeSearchLink(appName, metricId),
+    linkFormatter: getCodeSearchLink,
   },
 ];
 export const METRIC_METADATA_SCHEMA = [

--- a/src/formatters/codesearch.js
+++ b/src/formatters/codesearch.js
@@ -1,4 +1,5 @@
 import { camelCase, upperFirst, snakeCase } from "lodash";
+import { getGithubRepoName } from "./links";
 
 const searchfoxMap = {
   fenix: "fenix",
@@ -48,7 +49,7 @@ const sourcegraphMap = {
   mozilla_vpn: "mozilla-vpn-client",
 };
 
-export const getCodeSearchLink = (app, metric) => {
+export function getCodeSearchLink(metric, app, item) {
   const [category, name] = metric.split(/\.(?=[^.]+$)/);
 
   // Generate all possible casings for a search query:
@@ -79,9 +80,12 @@ export const getCodeSearchLink = (app, metric) => {
   /* eslint no-else-return: "error" */
 
   if (searchfoxMap[app]) {
+    const repoName = getGithubRepoName(item.source_url);
+    const searchFoxPath =
+      repoName === "application-services" ? repoName : searchfoxMap[app];
     return app === "firefox_desktop"
       ? `https://searchfox.org/mozilla-central/search?q=${allLanguagePatterns}&regexp=true`
-      : `https://searchfox.org/mozilla-mobile/search?q=${allLanguagePatterns}&path=${searchfoxMap[app]}&regexp=true`;
+      : `https://searchfox.org/mozilla-mobile/search?q=${allLanguagePatterns}&path=${searchFoxPath}&regexp=true`;
   } else if (sourcegraphMap[app]) {
     return (
       `https://sourcegraph.com/search?q=repo:%5Egithub%5C.com%5C/%5BMm%5Dozilla%28.*%29%5C/` +
@@ -90,4 +94,4 @@ export const getCodeSearchLink = (app, metric) => {
   }
 
   return undefined;
-};
+}

--- a/src/formatters/links.js
+++ b/src/formatters/links.js
@@ -37,3 +37,16 @@ export function getSourceUrlTitle(url) {
   }
   return url;
 }
+
+export function getGithubRepoName(url) {
+  const urlObj = new URL(url);
+  if (!urlObj.hostname.endsWith("github.com")) {
+    return null;
+  }
+  // Segments without falsy values that can be introduced by things like '//'
+  const pathSegments = urlObj.pathname.split("/").filter(Boolean);
+  if (pathSegments.length < 2) {
+    return null;
+  }
+  return pathSegments[1];
+}

--- a/tests/formatters.codesearch.test.js
+++ b/tests/formatters.codesearch.test.js
@@ -2,11 +2,17 @@ import { getCodeSearchLink } from "../src/formatters/codesearch";
 
 describe("Searchfox links for firefox-desktop", () => {
   it("works as expected", () => {
-    expect(getCodeSearchLink("firefox_desktop", "test.metric_name")).toBe(
+    expect(
+      getCodeSearchLink("test.metric_name", "firefox_desktop", {
+        source_url: "https://foo.bar",
+      })
+    ).toBe(
       "https://searchfox.org/mozilla-central/search?q=test.metric_name|test.metricName|Test.metricName|test.metric_name|test::metric_name&regexp=true"
     );
     expect(
-      getCodeSearchLink("firefox_desktop", "test_category.test_name")
+      getCodeSearchLink("test_category.test_name", "firefox_desktop", {
+        source_url: "https://foo.bar",
+      })
     ).toBe(
       "https://searchfox.org/mozilla-central/search?q=test_category.test_name|testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&regexp=true"
     );
@@ -15,18 +21,46 @@ describe("Searchfox links for firefox-desktop", () => {
 
 describe("Searchfox links for applications in mozilla-mobile", () => {
   it("works as expected", () => {
-    expect(getCodeSearchLink("fenix", "test.metric_name")).toBe(
+    expect(
+      getCodeSearchLink("test.metric_name", "fenix", {
+        source_url: "https://foo.bar",
+      })
+    ).toBe(
       "https://searchfox.org/mozilla-mobile/search?q=test.metric_name|test.metricName|Test.metricName|test.metric_name|test::metric_name&path=fenix&regexp=true"
     );
-    expect(getCodeSearchLink("fenix", "test_category.test_name")).toBe(
+    expect(
+      getCodeSearchLink("test_category.test_name", "fenix", {
+        source_url: "https://foo.bar",
+      })
+    ).toBe(
       "https://searchfox.org/mozilla-mobile/search?q=test_category.test_name|testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&path=fenix&regexp=true"
+    );
+    expect(
+      getCodeSearchLink("test_category.test_name", "fenix", {
+        source_url:
+          "https://github.com/mozilla/application-services/foo/bar/metrics.yaml",
+      })
+    ).toBe(
+      "https://searchfox.org/mozilla-mobile/search?q=test_category.test_name|testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&path=application-services&regexp=true"
+    );
+    expect(
+      getCodeSearchLink("test_category.test_name", "firefox_ios", {
+        source_url:
+          "https://github.com/mozilla/application-services/foo/bar/metrics.yaml",
+      })
+    ).toBe(
+      "https://searchfox.org/mozilla-mobile/search?q=test_category.test_name|testCategory.testName|TestCategory.testName|test_category.test_name|test_category::test_name&path=application-services&regexp=true"
     );
   });
 });
 
 describe("returns Sourcegraph link if the application is not indexed on Searchfox", () => {
   it("works as expected", () => {
-    expect(getCodeSearchLink("mozregression", "usage.bad_date")).toBe(
+    expect(
+      getCodeSearchLink("usage.bad_date", "mozregression", {
+        source_url: "https://foo.bar",
+      })
+    ).toBe(
       "https://sourcegraph.com/search?q=repo:%5Egithub%5C.com%5C/%5BMm%5Dozilla%28.*%29%5C/mozregression%24+usage.bad_date|usage.badDate|Usage.badDate|usage.bad_date|usage::bad_date&patternType=regexp"
     );
   });
@@ -34,6 +68,8 @@ describe("returns Sourcegraph link if the application is not indexed on Searchfo
 
 describe("returns undefined if the application cannot be indexed", () => {
   it("works as expected", () => {
-    expect(getCodeSearchLink("foo", "test.metric")).toBeUndefined();
+    expect(
+      getCodeSearchLink("test.metric", "foo", { source_url: "https://foo.bar" })
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fixes https://github.com/mozilla/glean-dictionary/issues/2248

Uses `application-services` as search path on Searchfox whenever `source_url` points to [application-services](https://github.com/mozilla/application-services)

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [x] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [x] All tests and linter checks are passing
- [x] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
