### PR TITLE
Update AuthenticatedLink.svelte to be more precise

### DIFF
--- a/src/components/AuthenticatedLink.svelte
+++ b/src/components/AuthenticatedLink.svelte
@@ -11,7 +11,7 @@
   class="lock-link"
   href="https://docs.telemetry.mozilla.org/concepts/gaining_access.html"
   use:tippy={{
-    content: "Access to this resource is limited to NDA'd Mozillians",
+    content: "Access to this resource is limited to NDA'd Mozillians who have a demonstrated need to access this data",
     placement: "top",
   }}
 >


### PR DESCRIPTION
Current statement is incorrect, as I, for example, am NDA'd myself (as per the badge on my profile https://people.mozilla.org/p/dan2023 ), but when logging into my account and visiting a page like https://dictionary.telemetry.mozilla.org/apps/firefox_desktop/metrics/media_video_widevine_play_time and clicking on any access link other than the GLAM links, this error appears (on an "https://sso.mozilla.com/forbidden?error=...... error page"): "Sorry, you do not have permission to access Looker production. Please contact the application owner for access. If unsure who that may be, please contact ServiceDesk@mozilla.com for support."

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ x ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ unknown ] All tests and linter checks are passing
- [ unknown ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
