### PR TITLE
Show removal status of pings

### DIFF
--- a/etl/glean.py
+++ b/etl/glean.py
@@ -136,6 +136,7 @@ class GleanPing(GleanObject):
         self.definition["name"] = full_defn[self.NAME_KEY]
         self.definition["origin"] = full_defn[self.ORIGIN_KEY]
         self.definition["date_first_seen"] = self.definition_history[-1]["dates"]["first"]
+        self.definition["in_source"] = full_defn[self.IN_SOURCE_KEY]
 
 
 class GleanTag(GleanObject):

--- a/etl_tests/test_looker.py
+++ b/etl_tests/test_looker.py
@@ -19,6 +19,7 @@ def fake_ping():
             "history": [
                 {"dates": {"first": "2020-01-01", "last": "2021-01-01"}, "metadata": {"tags": []}}
             ],
+            "in-source": True,
         },
     )
 

--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -169,6 +169,22 @@
       </label>
     </span>
   {/if}
+  {#if itemType === "pings"}
+    <span class="expire-checkbox">
+      <label>
+        <input
+          type="checkbox"
+          bind:checked={showUncollected}
+          on:change={() => {
+            // the binding changes *after* this callback is called, so use
+            // the inverse value
+            updateURLState({ showUncollected: !showUncollected });
+          }}
+        />
+        Show removed pings
+      </label>
+    </span>
+  {/if}
   {#if showFilter}
     <FilterInput
       tooltipped={true}

--- a/src/pages/PingDetail.svelte
+++ b/src/pages/PingDetail.svelte
@@ -24,12 +24,13 @@
   import {
     getLibraryDescription,
     getRecentlyAddedItemDescription,
+    getRemovedItemDescription,
   } from "../data/help";
   import { PING_SCHEMA } from "../data/schemas";
   import { getLibraryName } from "../formatters/library";
   import { stripLinks } from "../formatters/markdown";
   import { getMetricSearchURL } from "../state/urls";
-  import { isRecent } from "../state/items";
+  import { isRemoved, isRecent } from "../state/items";
   import { getAppBreadcrumbs } from "./AppDetail.svelte";
   import { getGleanPingQuery } from "../data/gleanSql";
 
@@ -55,6 +56,10 @@
 </script>
 
 {#await pingDataPromise then ping}
+  {#if isRemoved(ping)}
+    <AppAlert status="warning" message={getRemovedItemDescription("ping")} />
+  {/if}
+
   <PageHeader title={ping.name}>
     <svelte:fragment slot="tags">
       {#if ping.origin && ping.origin !== params.app}


### PR DESCRIPTION
Turns out ... we never displayed that for pings!

With this PR things will look like this:

Overview:

![image](https://github.com/user-attachments/assets/e0d8c4e6-4041-4520-be2f-6a21c842750a)

Detail page:

![image](https://github.com/user-attachments/assets/0e21af31-7153-4830-a9a6-0810bfacc5b0)

Basically the same as it does for metrics.

(This is preparation for https://bugzilla.mozilla.org/show_bug.cgi?id=1959916, and also uncovered another bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1960299)