### PR TITLE
Improve filtering speed by caching the search index

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -1,6 +1,5 @@
 <script>
   import { chunk, escapeRegExp } from "lodash";
-  import { Document } from "flexsearch";
 
   import { getItemURL } from "../state/urls";
   import { stripLinks } from "../formatters/markdown";
@@ -24,7 +23,7 @@
 
   import { adjustDataTypes } from "./AdjustDataTypes.svelte";
 
-  import { fullTextSearch } from "../state/search";
+  import { generateSearchIndex, fullTextSearch } from "../state/search";
 
   let DEFAULT_ITEMS_PER_PAGE = 20;
 
@@ -46,20 +45,7 @@
   let scrollY;
   let totalItems;
 
-  const searchIndex = new Document({
-    tokenize: "forward",
-    index: ["id", "type", "tags", "origin", "description"],
-  });
-
-  items.forEach((item) => {
-    searchIndex.add({
-      id: item.name,
-      type: item.type,
-      tags: item.tags,
-      origin: item.origin,
-      description: item.description,
-    });
-  });
+  const searchIndex = generateSearchIndex(items);
 
   function getItemTypeSingular(pluralized) {
     // cut off the trailing 's'
@@ -90,7 +76,7 @@
   $: {
     // after filtering for text, but before filtering for uncollected
     // (expired or removed)
-    filteredItems = search ? fullTextSearch(search, items) : items;
+    filteredItems = search ? fullTextSearch(searchIndex, search, items) : items;
     totalItems = filteredItems.length;
 
     // filter out metrics that do not belong to the application

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -2,7 +2,7 @@ import { Document } from "flexsearch";
 
 import { filterItemsByLabels, filterItemsByExpiration } from "./filter";
 
-const generateSearchIndex = (items) => {
+export const generateSearchIndex = (items) => {
   const searchIndex = new Document({
     tokenize: "forward",
     index: ["id", "type", "tags", "origin", "description", "bugs"],
@@ -23,7 +23,7 @@ const generateSearchIndex = (items) => {
   return searchIndex;
 };
 
-export const fullTextSearch = (query, searchItems) => {
+export const fullTextSearch = (searchIndex, query, searchItems) => {
   let itemsFilteredByLabels = searchItems;
   let unlabeledsearchTerms = [];
 
@@ -36,7 +36,6 @@ export const fullTextSearch = (query, searchItems) => {
     name: [],
     bugs: [],
   };
-  const searchIndex = generateSearchIndex(searchItems);
 
   searchTerms.forEach((term) => {
     if (

--- a/tests/state.search.test.js
+++ b/tests/state.search.test.js
@@ -1,4 +1,4 @@
-import { fullTextSearch } from "../src/state/search";
+import { generateSearchIndex, fullTextSearch } from "../src/state/search";
 
 const getNames = (items) => items.map((i) => i.name);
 
@@ -58,44 +58,44 @@ const items = [
   },
 ];
 
+const searchIndex = generateSearchIndex(items);
+
 describe("search", () => {
   it("returns items of Foo tags and sync origin", () =>
-    expect(getNames(fullTextSearch("tags:Foo origin:sync", items))).toEqual([
-      "metric.three",
-      "metric.four",
-      "metric.five",
-    ]));
+    expect(
+      getNames(fullTextSearch(searchIndex, "tags:Foo origin:sync", items))
+    ).toEqual(["metric.three", "metric.four", "metric.five"]));
 
   it("returns items of Foo tags, sync origin, with search word 'three'", () =>
     expect(
-      getNames(fullTextSearch("three tags:Foo origin:sync", items))
+      getNames(fullTextSearch(searchIndex, "three tags:Foo origin:sync", items))
     ).toEqual(["metric.three"]));
 
   it("returns the items that match the description `abc`", () =>
-    expect(getNames(fullTextSearch("abc", items))).toEqual([
+    expect(getNames(fullTextSearch(searchIndex, "abc", items))).toEqual([
       "metric.one",
       "metric.five",
     ]));
 
   it("returns only type string items", () =>
-    expect(getNames(fullTextSearch("string", items))).toEqual([
+    expect(getNames(fullTextSearch(searchIndex, "string", items))).toEqual([
       "metric.one",
       "metric.two",
       "metric.four",
     ]));
 
   it("works correctly with tags that has a `:` in its name", () =>
-    expect(getNames(fullTextSearch("tags:A:Tag", items))).toEqual([
+    expect(getNames(fullTextSearch(searchIndex, "tags:A:Tag", items))).toEqual([
       "metric.six",
     ]));
 
   it("works correctly with tags with spaces", () =>
-    expect(getNames(fullTextSearch('tags:"Tag with spaces"', items))).toEqual([
-      "metric.seven",
-    ]));
+    expect(
+      getNames(fullTextSearch(searchIndex, 'tags:"Tag with spaces"', items))
+    ).toEqual(["metric.seven"]));
 
   it("exact match non-tokenized", () =>
-    expect(getNames(fullTextSearch('"mno pqr stu"', items))).toEqual([
-      "metric.eight",
-    ]));
+    expect(
+      getNames(fullTextSearch(searchIndex, '"mno pqr stu"', items))
+    ).toEqual(["metric.eight"]));
 });


### PR DESCRIPTION
Currently, on my Firefox, when I visit https://dictionary.telemetry.mozilla.org/apps/firefox_desktop?page=1 and filter the metrics, there's a noticeable lag between typing and the display updating. Profiling this shows jank that can cover half a second when typing multiple characters.

When the filtering was [first implemented](https://github.com/mozilla/glean-dictionary/commit/52c128a7a1ee7abf5f062a5acfe0de8d9ea13904), `ItemList.svelte` created its own `searchIndex` and used that its `fullTextSearch` function. However, when the code was re-arranged in 80cb86f2106a7d1e79607abd9aeb3663f498933f, the `fullTextSearch` started to create a new `searchIndex` for every search. It is now processing ~6400 items each time.

Hence, this PR is using the `searchIndex` created in `ItemList.svelte` as a cache to avoid the re-generation. With this change the jank is limited to an initial ~170ms, and then all interactions are very responsive, with no more jank.

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [X] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [X] All tests and linter checks are passing
- [X] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
