### PR TITLE
Fix Show sampled metrics logic

### DIFF
--- a/src/components/ItemList.svelte
+++ b/src/components/ItemList.svelte
@@ -90,8 +90,8 @@
       : filterUncollectedItems(filteredItems);
 
     filteredItems = showSampled
-      ? filteredItems.filter((item) => item.sampled)
-      : filteredItems;
+      ? filteredItems
+      : filteredItems.filter((item) => !item.sampled);
 
     // update pagination
     const currentPage = $pageState.page || 1;


### PR DESCRIPTION
### Pull Request checklist

Fixes https://github.com/mozilla/glean-dictionary/issues/2281

I see this as a bug in the `Show sampled metrics` logic, which is behaving like "Show **only** sampled metrics". I also assumed that the preferred behaviour is the former.

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
