### PR TITLE
Display monitor metadata for metric

### DIFF
--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -476,7 +476,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                             is_part_of_info_section=metric.bq_prefix
                             in ["client_info", "ping_info"],
                             bugs=metric.definition["bugs"],
-                            monitor=metric.definition.get("metadata", {}).get("monitor", {})
+                            monitor=metric.definition.get("metadata", {}).get("monitor", {}),
                         ),
                         metric_annotation,
                     )

--- a/etl/glean_etl.py
+++ b/etl/glean_etl.py
@@ -476,6 +476,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                             is_part_of_info_section=metric.bq_prefix
                             in ["client_info", "ping_info"],
                             bugs=metric.definition["bugs"],
+                            monitor=metric.definition.get("metadata", {}).get("monitor", {})
                         ),
                         metric_annotation,
                     )
@@ -508,6 +509,7 @@ def write_glean_metadata(output_dir, functions_dir, app_names=None):
                                 canonical_app_name=app.app["canonical_app_name"],
                                 app_tags=app_tags_for_app,
                                 sampling_info=metric_sample_info,
+                                monitor=base_definition["monitor"],
                             ),
                             metric_annotation,
                             full=True,

--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -16,7 +16,8 @@ const OPTIONAL_METRIC_PARAMS_DOCS =
   "https://mozilla.github.io/glean/book/user/metric-parameters.html#optional-metric-parameters";
 const PING_REASONS_DOCS =
   "https://mozilla.github.io/glean/book/reference/yaml/pings.html#reasons";
-const METRIC_MONITOR_DOCS = "https://firefox-source-docs.mozilla.org/testing/perfdocs/telemetry-alerting.html#probe-setup"
+const METRIC_MONITOR_DOCS =
+  "https://firefox-source-docs.mozilla.org/testing/perfdocs/telemetry-alerting.html#probe-setup";
 
 const getFirstAddedText = (itemType) =>
   `The date when this ${itemType} was first added to the product source code. If it was added recently, it may take some time before the software is released to users and data starts showing up.`;

--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -8,6 +8,7 @@ import {
 } from "../formatters/links";
 import { getCodeSearchLink } from "../formatters/codesearch";
 import { getPingReasons } from "../formatters/text";
+import { formatMonitor } from "../formatters/monitor";
 
 const REQUIRED_METRIC_PARAMS_DOCS =
   "https://mozilla.github.io/glean/book/user/metric-parameters.html#required-metric-parameters";
@@ -15,6 +16,7 @@ const OPTIONAL_METRIC_PARAMS_DOCS =
   "https://mozilla.github.io/glean/book/user/metric-parameters.html#optional-metric-parameters";
 const PING_REASONS_DOCS =
   "https://mozilla.github.io/glean/book/reference/yaml/pings.html#reasons";
+const METRIC_MONITOR_DOCS = "https://firefox-source-docs.mozilla.org/testing/perfdocs/telemetry-alerting.html#probe-setup"
 
 const getFirstAddedText = (itemType) =>
   `The date when this ${itemType} was first added to the product source code. If it was added recently, it may take some time before the software is released to users and data starts showing up.`;
@@ -220,6 +222,15 @@ export const METRIC_METADATA_SCHEMA = [
       "When the metric is set to expire. After a metric expires, an application will no longer collect or send data related to it.",
     helpLink: REQUIRED_METRIC_PARAMS_DOCS,
     valueFormatter: getExpiryInfo,
+  },
+  {
+    title: "Monitor",
+    id: "monitor",
+    type: "boolean",
+    helpText:
+      "Information about telemetry alerting monitoring for this metric. Click to read more.",
+    helpLink: METRIC_MONITOR_DOCS,
+    valueFormatter: formatMonitor,
   },
 ];
 export const PING_SCHEMA = [

--- a/src/formatters/monitor.js
+++ b/src/formatters/monitor.js
@@ -31,5 +31,7 @@ export function formatMonitor(monitor) {
     changeDetectionTechnique: change_detection_technique || null,
     changeDetectionArgs: change_detection_args,
   };
-  return ["<pre><code>", JSON.stringify(json, null, 2), "</code></pre>"].join("");
+  return ["<pre><code>", JSON.stringify(json, null, 2), "</code></pre>"].join(
+    ""
+  );
 }

--- a/src/formatters/monitor.js
+++ b/src/formatters/monitor.js
@@ -1,0 +1,35 @@
+/* eslint-disable camelcase */
+export function formatMonitor(monitor) {
+  if (typeof monitor === "boolean") {
+    return monitor ? "Enabled" : "Disabled";
+  }
+  if (
+    typeof monitor !== "object" ||
+    monitor === null ||
+    Object.keys(monitor).length === 0
+  ) {
+    return "Disabled";
+  }
+  const {
+    alert,
+    platforms = [],
+    bugzilla_notification_emails = [],
+    lower_is_better,
+    change_detection_technique,
+    change_detection_args = [],
+  } = monitor;
+  const notificationEmails =
+    Array.isArray(bugzilla_notification_emails) &&
+    bugzilla_notification_emails.length > 0
+      ? bugzilla_notification_emails
+      : [];
+  const json = {
+    alert: alert ? "Enabled" : "Disabled",
+    platforms: platforms.length ? platforms : [],
+    notificationEmails,
+    lowerIsBetter: lower_is_better === undefined ? null : !!lower_is_better,
+    changeDetectionTechnique: change_detection_technique || null,
+    changeDetectionArgs: change_detection_args,
+  };
+  return ["<pre><code>", JSON.stringify(json, null, 2), "</code></pre>"].join("");
+}

--- a/tests/formatters.monitor.test.js
+++ b/tests/formatters.monitor.test.js
@@ -1,0 +1,48 @@
+import { formatMonitor } from "../src/formatters/monitor";
+
+describe("formatMonitor", () => {
+  it("returns 'Enabled' for boolean true", () => {
+    expect(formatMonitor(true)).toBe("Enabled");
+  });
+
+  it("returns 'Disabled' for boolean false", () => {
+    expect(formatMonitor(false)).toBe("Disabled");
+  });
+
+  it("returns 'Disabled' for non-object, non-boolean", () => {
+    expect(formatMonitor(123)).toBe("Disabled");
+    expect(formatMonitor("foo")).toBe("Disabled");
+    expect(formatMonitor(null)).toBe("Disabled");
+  });
+
+  it("returns markdown JSON for a full monitor object", () => {
+    const monitor = {
+      alert: true,
+      platforms: ["Windows", "Linux"],
+      bugzilla_notification_emails: ["a@b.com", "c@d.com"],
+      lower_is_better: true,
+      change_detection_technique: "cdf-squared",
+      change_detection_args: ["threshold=0.85"],
+    };
+    const result = formatMonitor(monitor);
+    expect(result).toContain("<pre><code>");
+    expect(result).toContain('"alert": "Enabled"');
+    expect(result).toContain('"platforms": [\n    "Windows",\n    "Linux"\n  ]');
+    expect(result).toContain('"notificationEmails": [\n    "a@b.com",\n    "c@d.com"\n  ]');
+    expect(result).toContain('"lowerIsBetter": true');
+    expect(result).toContain('"changeDetectionTechnique": "cdf-squared"');
+    expect(result).toContain('"changeDetectionArgs": [\n    "threshold=0.85"\n  ]');
+    expect(result).toContain("</code></pre>");
+  });
+
+  it("returns markdown JSON with defaults for missing fields", () => {
+    const monitor = { alert: false };
+    const result = formatMonitor(monitor);
+    expect(result).toContain('"alert": "Disabled"');
+    expect(result).toContain('"platforms": []');
+    expect(result).toContain('"notificationEmails": []');
+    expect(result).toContain('"lowerIsBetter": null');
+    expect(result).toContain('"changeDetectionTechnique": null');
+    expect(result).toContain('"changeDetectionArgs": []');
+  });
+});

--- a/tests/formatters.monitor.test.js
+++ b/tests/formatters.monitor.test.js
@@ -27,11 +27,17 @@ describe("formatMonitor", () => {
     const result = formatMonitor(monitor);
     expect(result).toContain("<pre><code>");
     expect(result).toContain('"alert": "Enabled"');
-    expect(result).toContain('"platforms": [\n    "Windows",\n    "Linux"\n  ]');
-    expect(result).toContain('"notificationEmails": [\n    "a@b.com",\n    "c@d.com"\n  ]');
+    expect(result).toContain(
+      '"platforms": [\n    "Windows",\n    "Linux"\n  ]'
+    );
+    expect(result).toContain(
+      '"notificationEmails": [\n    "a@b.com",\n    "c@d.com"\n  ]'
+    );
     expect(result).toContain('"lowerIsBetter": true');
     expect(result).toContain('"changeDetectionTechnique": "cdf-squared"');
-    expect(result).toContain('"changeDetectionArgs": [\n    "threshold=0.85"\n  ]');
+    expect(result).toContain(
+      '"changeDetectionArgs": [\n    "threshold=0.85"\n  ]'
+    );
     expect(result).toContain("</code></pre>");
   });
 


### PR DESCRIPTION
Adds monitor information for metrics.
Monitor information can be an Object, a Boolean or absent. The screenshots below show what happens for each case, in that order.
[More info](https://firefox-source-docs.mozilla.org/testing/perfdocs/telemetry-alerting.html#probe-setup)

---------------------------
<img width="581" height="698" alt="Screenshot 2025-07-25 at 10 45 43 AM" src="https://github.com/user-attachments/assets/e91f1b0d-0cca-494e-85e1-a01d4b8942e4" />
<img width="495" height="393" alt="Screenshot 2025-07-25 at 10 06 33 AM" src="https://github.com/user-attachments/assets/b194f0ce-66fd-4431-b60e-1d04f1b67ed0" />
<img width="451" height="382" alt="Screenshot 2025-07-25 at 10 06 17 AM" src="https://github.com/user-attachments/assets/3618186f-4b03-445b-8ede-ddcf35a818b7" />



### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
