### PR TITLE
Avoid the SQL code modal being overshadowed by the footer

### DIFF
--- a/src/components/SqlModal.svelte
+++ b/src/components/SqlModal.svelte
@@ -73,6 +73,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    z-index: 1000;
   }
   .gp-modal__backdrop {
     position: absolute;
@@ -82,7 +83,6 @@
   }
   .gp-modal__wrapper {
     position: relative;
-    z-index: 1000;
     border-radius: 0.5rem;
     background-color: $color-light-gray-10;
     overflow: hidden;


### PR DESCRIPTION
The modal was not in front _enough_, so the footer could be placed in front of it, making it look very awkward.
We need to z-index the whole modal to fix that.

Before:

<img width="2696" height="1462" alt="Screenshot 2025-07-31 at 11-19-27 a11y always_underline_links Firefox for Desktop" src="https://github.com/user-attachments/assets/83246ee1-f426-47dc-9222-792b842047d6" />

After:

<img width="2698" height="1398" alt="Screenshot 2025-07-31 at 11-19-38 a11y always_underline_links Firefox for Desktop" src="https://github.com/user-attachments/assets/36114e4c-5ed2-4dcc-b44d-93799098ed13" />
