### PR TITLE
Gracefully handle non-existance of `event_name` when trying to get auto-events

### DIFF
--- a/etl/glean_auto_events.py
+++ b/etl/glean_auto_events.py
@@ -42,9 +42,12 @@ def get_auto_events_for_app(app, auto_events):
     event_names = [event for event in auto_events if event["app"] == app]
     auto_events = []
     for row in event_names:
-        auto_event_id = row["event_name"].split(".")[-1]
+        event_name = row.get("event_name")
+        if not event_name:
+            continue
+        auto_event_id = event_name.split(".")[-1]
         event_template = copy.deepcopy(_auto_event_template)
-        event_template["name"] = row["event_name"]
+        event_template["name"] = event_name
         auto_event_type_prefix = event_template["name"].split(".")[1]
         if auto_event_type_prefix.startswith("element_click"):
             event_template["description"] = (


### PR DESCRIPTION
Fixes #2310

Checking the [public data this is based on](https://public-data.telemetry.mozilla.org/api/v1/tables/glean_auto_events_derived/apps_auto_events_metadata/v1/files/000000000000.json) this is (part of) what's currently in there:

```
[
  {
    "app": "accounts_frontend",
    "count": "1"
  },
  {
    "app": "accounts_frontend",
    "event_name": "glean.element_click.email_first_submit1DasO6R8')) OR 887=(SELECT 887 FROM PG_SLEEP(15))--",
    "count": "1"
  },
````

The first entry doesn't have any `event_name` (and others have some SQL injection tries there).
I don't actually know where we generate that file. We can probably fix it in the generation to not even generate that first entry, but regardless I think this dictionary ETL should be resistant against slightly wrong input data.