### PR TITLE
Resolve library dependency pings/metrics/tags in MCP server

### DIFF
--- a/.netlify/mcp.js
+++ b/.netlify/mcp.js
@@ -6,8 +6,10 @@
 const PROBEINFO_BASE_URL = "https://probeinfo.telemetry.mozilla.org";
 const ANNOTATIONS_URL = "https://mozilla.github.io/glean-annotations/api.json";
 
-// Cache for annotations (shared across invocations in same instance)
+// Caches (shared across invocations in same instance)
 let cachedAnnotations = null;
+let cachedLibraryVariants = null;
+let cachedAppListings = null;
 
 /**
  * Fetch JSON from a URL
@@ -36,10 +38,45 @@ async function getAnnotations() {
 }
 
 /**
- * Get all app listings from probeinfo
+ * Get library variants mapping (cached)
+ */
+async function getLibraryVariants() {
+  if (cachedLibraryVariants) return cachedLibraryVariants;
+  try {
+    cachedLibraryVariants = await fetchJson(
+      `${PROBEINFO_BASE_URL}/v2/glean/library-variants`
+    );
+    return cachedLibraryVariants;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get v1 names for an app's library dependencies
+ */
+async function getDependencyV1Names(app) {
+  const depNames = app.dependencies || [];
+  if (depNames.length === 0) return [];
+
+  const variants = await getLibraryVariants();
+  const byDepName = {};
+  for (const lib of variants) {
+    byDepName[lib.dependency_name] = lib.v1_name;
+  }
+
+  return depNames.map((name) => byDepName[name]).filter(Boolean);
+}
+
+/**
+ * Get all app listings from probeinfo (cached)
  */
 async function getAppListings() {
-  return fetchJson(`${PROBEINFO_BASE_URL}/v2/glean/app-listings`);
+  if (cachedAppListings) return cachedAppListings;
+  cachedAppListings = await fetchJson(
+    `${PROBEINFO_BASE_URL}/v2/glean/app-listings`
+  );
+  return cachedAppListings;
 }
 
 /**
@@ -56,43 +93,55 @@ async function findApp(appName) {
 }
 
 /**
- * Get v1 API identifier for an app
+ * Fetch a probeinfo endpoint for an app and its library dependencies, merging results.
+ * App-defined entries take precedence over library entries.
  */
-function getV1AppId(app) {
-  return app.v1_name;
-}
-
-/**
- * Get metrics for an app
- */
-async function getMetrics(appName) {
+async function fetchWithDependencies(appName, endpoint) {
   const app = await findApp(appName);
   if (!app) throw new Error(`App not found: ${appName}`);
-  return fetchJson(`${PROBEINFO_BASE_URL}/glean/${getV1AppId(app)}/metrics`);
-}
 
-/**
- * Get pings for an app
- */
-async function getPings(appName) {
-  const app = await findApp(appName);
-  if (!app) throw new Error(`App not found: ${appName}`);
-  return fetchJson(`${PROBEINFO_BASE_URL}/glean/${getV1AppId(app)}/pings`);
-}
+  const [appData, depV1Names] = await Promise.all([
+    fetchJson(
+      `${PROBEINFO_BASE_URL}/glean/${app.v1_name}/${endpoint}`
+    ).catch(() => ({})),
+    getDependencyV1Names(app),
+  ]);
 
-/**
- * Get tags for an app
- */
-async function getTags(appName) {
-  const app = await findApp(appName);
-  if (!app) throw new Error(`App not found: ${appName}`);
-  try {
-    return await fetchJson(
-      `${PROBEINFO_BASE_URL}/glean/${getV1AppId(app)}/tags`
-    );
-  } catch {
-    return {};
+  const merged = { ...appData };
+  const depResults = await Promise.all(
+    depV1Names.map((v1) =>
+      fetchJson(`${PROBEINFO_BASE_URL}/glean/${v1}/${endpoint}`).catch(
+        () => ({})
+      )
+    )
+  );
+  for (const depData of depResults) {
+    for (const [name, def] of Object.entries(depData)) {
+      if (!merged[name]) merged[name] = def;
+    }
   }
+  return merged;
+}
+
+/**
+ * Get metrics for an app (including library dependencies)
+ */
+function getMetrics(appName) {
+  return fetchWithDependencies(appName, "metrics");
+}
+
+/**
+ * Get pings for an app (including library dependencies)
+ */
+function getPings(appName) {
+  return fetchWithDependencies(appName, "pings");
+}
+
+/**
+ * Get tags for an app (including library dependencies)
+ */
+function getTags(appName) {
+  return fetchWithDependencies(appName, "tags");
 }
 
 // ============================================================================
@@ -459,6 +508,9 @@ async function handleJsonRpc(request) {
 
   switch (method) {
     case "initialize":
+      cachedAnnotations = null;
+      cachedLibraryVariants = null;
+      cachedAppListings = null;
       return {
         jsonrpc: "2.0",
         id,

--- a/.netlify/mcp.js
+++ b/.netlify/mcp.js
@@ -101,9 +101,9 @@ async function fetchWithDependencies(appName, endpoint) {
   if (!app) throw new Error(`App not found: ${appName}`);
 
   const [appData, depV1Names] = await Promise.all([
-    fetchJson(
-      `${PROBEINFO_BASE_URL}/glean/${app.v1_name}/${endpoint}`
-    ).catch(() => ({})),
+    fetchJson(`${PROBEINFO_BASE_URL}/glean/${app.v1_name}/${endpoint}`).catch(
+      () => ({})
+    ),
     getDependencyV1Names(app),
   ]);
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,10 +4,8 @@ command = """
     pip install -e .
     ./scripts/gd build-metadata
     # glean.js currently requires a virtual environment
-    python -mvenv venv --without-pip
-    wget https://bootstrap.pypa.io/get-pip.py
-    venv/bin/python get-pip.py
-    venv/bin/pip install wheel
+    python3 -m venv venv
+    venv/bin/pip3 install setuptools wheel
     npm ci
     npm run build
     if [ "$STORYBOOK" ]; then

--- a/tests/mcp.test.js
+++ b/tests/mcp.test.js
@@ -140,8 +140,14 @@ describe("MCP Server protocol methods", () => {
 });
 
 describe("MCP Server tool calls", () => {
-  beforeEach(() => {
-    // Reset fetch mock
+  beforeEach(async () => {
+    global.fetch.mockReset();
+    // Clear module-level caches between tests
+    await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 0,
+      method: "initialize",
+    });
     global.fetch.mockReset();
   });
 
@@ -230,5 +236,578 @@ describe("MCP Server tool calls", () => {
 
     const errorData = JSON.parse(response.parsedBody.result.content[0].text);
     expect(errorData.error).toContain("Unknown tool");
+  });
+});
+
+describe("MCP Server library dependency resolution", () => {
+  beforeEach(async () => {
+    global.fetch.mockReset();
+    // Clear module-level caches between tests
+    await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 0,
+      method: "initialize",
+    });
+    global.fetch.mockReset();
+  });
+
+  function mockFetchForDeps({
+    appListings,
+    libraryVariants,
+    appMetrics = {},
+    appPings = {},
+    appTags = {},
+    depEndpoints = {},
+  }) {
+    global.fetch.mockImplementation((url) => {
+      if (url.includes("app-listings")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(appListings),
+        });
+      }
+      if (url.includes("library-variants")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(libraryVariants),
+        });
+      }
+      if (url.includes("annotations")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({}),
+        });
+      }
+      // Match dependency and app endpoints: /glean/{v1_name}/{type}
+      for (const [pattern, data] of Object.entries(depEndpoints)) {
+        if (url.includes(pattern)) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(data),
+          });
+        }
+      }
+      // App's own endpoints
+      if (url.includes("/glean/test-app/metrics")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(appMetrics),
+        });
+      }
+      if (url.includes("/glean/test-app/pings")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(appPings),
+        });
+      }
+      if (url.includes("/glean/test-app/tags")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(appTags),
+        });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+  }
+
+  const baseAppListings = [
+    {
+      app_name: "test_app",
+      app_description: "Test application",
+      canonical_app_name: "Test App",
+      deprecated: false,
+      url: "https://example.com",
+      v1_name: "test-app",
+      dependencies: ["glean-core"],
+    },
+  ];
+
+  const baseLibraryVariants = [
+    {
+      dependency_name: "glean-core",
+      v1_name: "glean-core",
+    },
+  ];
+
+  it("get_ping resolves library dependency pings", async () => {
+    mockFetchForDeps({
+      appListings: baseAppListings,
+      libraryVariants: baseLibraryVariants,
+      appPings: {
+        custom_ping: {
+          history: [{ description: "App-defined ping" }],
+        },
+      },
+      appMetrics: {},
+      depEndpoints: {
+        "/glean/glean-core/pings": {
+          baseline: {
+            history: [
+              {
+                description: "Baseline ping from glean-core",
+                include_client_id: true,
+                send_if_empty: false,
+                bugs: ["https://bugzilla.mozilla.org/1"],
+                data_reviews: ["https://example.com/review"],
+                reasons: { dirty_startup: "reason" },
+              },
+            ],
+          },
+        },
+        "/glean/glean-core/metrics": {
+          "glean.baseline.duration": {
+            history: [
+              {
+                type: "timespan",
+                description: "Baseline duration",
+                send_in_pings: ["baseline"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 20,
+      method: "tools/call",
+      params: { name: "get_ping", arguments: { app_name: "test_app", ping_name: "baseline" } },
+    });
+
+    expect(response.parsedBody.result.isError).toBeUndefined();
+    const result = JSON.parse(response.parsedBody.result.content[0].text);
+    expect(result.name).toBe("baseline");
+    expect(result.description).toBe("Baseline ping from glean-core");
+    expect(result.metrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "glean.baseline.duration" }),
+      ])
+    );
+  });
+
+  it("get_app includes library dependency pings and metrics", async () => {
+    mockFetchForDeps({
+      appListings: baseAppListings,
+      libraryVariants: baseLibraryVariants,
+      appPings: {
+        events: { history: [{ description: "Events ping" }] },
+      },
+      appMetrics: {
+        "app.metric": {
+          history: [{ type: "counter", description: "App metric", send_in_pings: ["events"] }],
+        },
+      },
+      depEndpoints: {
+        "/glean/glean-core/pings": {
+          baseline: { history: [{ description: "Baseline ping" }] },
+        },
+        "/glean/glean-core/metrics": {
+          "glean.baseline.duration": {
+            history: [{ type: "timespan", description: "Duration", send_in_pings: ["baseline"] }],
+          },
+        },
+        "/glean/glean-core/tags": {},
+      },
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 21,
+      method: "tools/call",
+      params: { name: "get_app", arguments: { app_name: "test_app" } },
+    });
+
+    const result = JSON.parse(response.parsedBody.result.content[0].text);
+    const pingNames = result.pings.map((p) => p.name);
+    expect(pingNames).toContain("baseline");
+    expect(pingNames).toContain("events");
+    expect(result.metrics_count).toBe(2);
+  });
+
+  it("search_metrics finds library dependency metrics", async () => {
+    mockFetchForDeps({
+      appListings: baseAppListings,
+      libraryVariants: baseLibraryVariants,
+      appMetrics: {},
+      depEndpoints: {
+        "/glean/glean-core/metrics": {
+          "glean.baseline.duration": {
+            history: [
+              {
+                type: "timespan",
+                description: "Baseline duration",
+                expires: "never",
+                send_in_pings: ["baseline"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 22,
+      method: "tools/call",
+      params: {
+        name: "search_metrics",
+        arguments: { app_name: "test_app", query: "glean.baseline" },
+      },
+    });
+
+    const result = JSON.parse(response.parsedBody.result.content[0].text);
+    expect(result.total).toBeGreaterThan(0);
+    expect(result.metrics[0].name).toBe("glean.baseline.duration");
+  });
+
+  it("app metrics take precedence over library metrics", async () => {
+    mockFetchForDeps({
+      appListings: baseAppListings,
+      libraryVariants: baseLibraryVariants,
+      appMetrics: {
+        "glean.baseline.duration": {
+          history: [
+            {
+              type: "timespan",
+              description: "App override of duration",
+              expires: "never",
+              send_in_pings: ["baseline"],
+            },
+          ],
+        },
+      },
+      depEndpoints: {
+        "/glean/glean-core/metrics": {
+          "glean.baseline.duration": {
+            history: [
+              {
+                type: "timespan",
+                description: "Library version of duration",
+                expires: "never",
+                send_in_pings: ["baseline"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 23,
+      method: "tools/call",
+      params: {
+        name: "get_metric",
+        arguments: { app_name: "test_app", metric_name: "glean.baseline.duration" },
+      },
+    });
+
+    const result = JSON.parse(response.parsedBody.result.content[0].text);
+    expect(result.description).toBe("App override of duration");
+  });
+
+  it("get_metric returns a library-only metric", async () => {
+    mockFetchForDeps({
+      appListings: baseAppListings,
+      libraryVariants: baseLibraryVariants,
+      appMetrics: {
+        "app.clicks": {
+          history: [
+            { type: "counter", description: "App clicks", expires: "never", send_in_pings: ["events"] },
+          ],
+        },
+      },
+      depEndpoints: {
+        "/glean/glean-core/metrics": {
+          "glean.baseline.duration": {
+            history: [
+              {
+                type: "timespan",
+                description: "Baseline duration from library",
+                expires: "never",
+                send_in_pings: ["baseline"],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 30,
+      method: "tools/call",
+      params: {
+        name: "get_metric",
+        arguments: { app_name: "test_app", metric_name: "glean.baseline.duration" },
+      },
+    });
+
+    expect(response.parsedBody.result.isError).toBeUndefined();
+    const result = JSON.parse(response.parsedBody.result.content[0].text);
+    expect(result.name).toBe("glean.baseline.duration");
+    expect(result.description).toBe("Baseline duration from library");
+    expect(result.type).toBe("timespan");
+  });
+
+  it("skips unresolvable dependency names without fallback", async () => {
+    mockFetchForDeps({
+      appListings: [
+        {
+          app_name: "test_app",
+          app_description: "Test",
+          canonical_app_name: "Test",
+          deprecated: false,
+          url: "https://example.com",
+          v1_name: "test-app",
+          dependencies: ["unknown-lib-1", "unknown-lib-2"],
+        },
+      ],
+      libraryVariants: baseLibraryVariants,
+      appPings: {
+        events: { history: [{ description: "App events ping" }] },
+      },
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 31,
+      method: "tools/call",
+      params: {
+        name: "get_ping",
+        arguments: { app_name: "test_app", ping_name: "baseline" },
+      },
+    });
+
+    // baseline does NOT exist because unknown deps can't be resolved
+    expect(response.parsedBody.result.isError).toBe(true);
+  });
+
+  it("returns only app data when dependencies array is empty", async () => {
+    mockFetchForDeps({
+      appListings: [
+        {
+          app_name: "test_app",
+          app_description: "Test",
+          canonical_app_name: "Test",
+          deprecated: false,
+          url: "https://example.com",
+          v1_name: "test-app",
+          dependencies: [],
+        },
+      ],
+      libraryVariants: baseLibraryVariants,
+      appPings: {
+        events: { history: [{ description: "App events ping" }] },
+      },
+      appMetrics: {
+        "app.clicks": {
+          history: [
+            {
+              type: "counter",
+              description: "App clicks",
+              expires: "never",
+              send_in_pings: ["events"],
+            },
+          ],
+        },
+      },
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 24,
+      method: "tools/call",
+      params: {
+        name: "search_metrics",
+        arguments: { app_name: "test_app" },
+      },
+    });
+
+    const result = JSON.parse(response.parsedBody.result.content[0].text);
+    expect(result.total).toBe(1);
+    expect(result.metrics[0].name).toBe("app.clicks");
+  });
+
+  it("returns only app data when dependencies field is undefined", async () => {
+    mockFetchForDeps({
+      appListings: [
+        {
+          app_name: "test_app",
+          app_description: "Test",
+          canonical_app_name: "Test",
+          deprecated: false,
+          url: "https://example.com",
+          v1_name: "test-app",
+          // no dependencies field at all
+        },
+      ],
+      libraryVariants: baseLibraryVariants,
+      appPings: {
+        events: { history: [{ description: "App events ping" }] },
+      },
+      appMetrics: {
+        "app.clicks": {
+          history: [
+            {
+              type: "counter",
+              description: "App clicks",
+              expires: "never",
+              send_in_pings: ["events"],
+            },
+          ],
+        },
+      },
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 25,
+      method: "tools/call",
+      params: {
+        name: "search_metrics",
+        arguments: { app_name: "test_app" },
+      },
+    });
+
+    const result = JSON.parse(response.parsedBody.result.content[0].text);
+    expect(result.total).toBe(1);
+    expect(result.metrics[0].name).toBe("app.clicks");
+  });
+
+  it("merges metrics from multiple library dependencies", async () => {
+    mockFetchForDeps({
+      appListings: [
+        {
+          app_name: "test_app",
+          app_description: "Test",
+          canonical_app_name: "Test",
+          deprecated: false,
+          url: "https://example.com",
+          v1_name: "test-app",
+          dependencies: ["glean-core", "gecko"],
+        },
+      ],
+      libraryVariants: [
+        { dependency_name: "glean-core", v1_name: "glean-core" },
+        { dependency_name: "gecko", v1_name: "gecko" },
+      ],
+      appMetrics: {
+        "app.clicks": {
+          history: [{ type: "counter", description: "App clicks", expires: "never", send_in_pings: ["events"] }],
+        },
+      },
+      depEndpoints: {
+        "/glean/glean-core/metrics": {
+          "glean.baseline.duration": {
+            history: [{ type: "timespan", description: "From glean-core", expires: "never", send_in_pings: ["baseline"] }],
+          },
+        },
+        "/glean/gecko/metrics": {
+          "gecko.page.load_time": {
+            history: [{ type: "timing_distribution", description: "From gecko", expires: "never", send_in_pings: ["metrics"] }],
+          },
+        },
+      },
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 26,
+      method: "tools/call",
+      params: {
+        name: "search_metrics",
+        arguments: { app_name: "test_app" },
+      },
+    });
+
+    const result = JSON.parse(response.parsedBody.result.content[0].text);
+    const names = result.metrics.map((m) => m.name);
+    expect(names).toContain("app.clicks");
+    expect(names).toContain("glean.baseline.duration");
+    expect(names).toContain("gecko.page.load_time");
+    expect(result.total).toBe(3);
+  });
+
+  it("still returns app data when a dependency fetch fails", async () => {
+    global.fetch.mockImplementation((url) => {
+      if (url.includes("app-listings")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              {
+                app_name: "test_app",
+                app_description: "Test",
+                canonical_app_name: "Test",
+                deprecated: false,
+                url: "https://example.com",
+                v1_name: "test-app",
+                dependencies: ["glean-core"],
+              },
+            ]),
+        });
+      }
+      if (url.includes("library-variants")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([
+              { dependency_name: "glean-core", v1_name: "glean-core" },
+            ]),
+        });
+      }
+      if (url.includes("annotations")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      // App's own metrics succeed
+      if (url.includes("/glean/test-app/metrics")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              "app.metric": {
+                history: [{ type: "counter", description: "App metric", expires: "never", send_in_pings: ["events"] }],
+              },
+            }),
+        });
+      }
+      // Dependency metrics fail with 500
+      if (url.includes("/glean/glean-core/metrics")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+        });
+      }
+      // Other app endpoints
+      if (url.includes("/glean/test-app/")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      if (url.includes("/glean/glean-core/")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+        });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    const response = await callHandler("POST", {
+      jsonrpc: "2.0",
+      id: 27,
+      method: "tools/call",
+      params: {
+        name: "search_metrics",
+        arguments: { app_name: "test_app" },
+      },
+    });
+
+    expect(response.parsedBody.result.isError).toBeUndefined();
+    const result = JSON.parse(response.parsedBody.result.content[0].text);
+    expect(result.total).toBe(1);
+    expect(result.metrics[0].name).toBe("app.metric");
   });
 });

--- a/tests/mcp.test.js
+++ b/tests/mcp.test.js
@@ -372,7 +372,10 @@ describe("MCP Server library dependency resolution", () => {
       jsonrpc: "2.0",
       id: 20,
       method: "tools/call",
-      params: { name: "get_ping", arguments: { app_name: "test_app", ping_name: "baseline" } },
+      params: {
+        name: "get_ping",
+        arguments: { app_name: "test_app", ping_name: "baseline" },
+      },
     });
 
     expect(response.parsedBody.result.isError).toBeUndefined();
@@ -395,7 +398,13 @@ describe("MCP Server library dependency resolution", () => {
       },
       appMetrics: {
         "app.metric": {
-          history: [{ type: "counter", description: "App metric", send_in_pings: ["events"] }],
+          history: [
+            {
+              type: "counter",
+              description: "App metric",
+              send_in_pings: ["events"],
+            },
+          ],
         },
       },
       depEndpoints: {
@@ -404,7 +413,13 @@ describe("MCP Server library dependency resolution", () => {
         },
         "/glean/glean-core/metrics": {
           "glean.baseline.duration": {
-            history: [{ type: "timespan", description: "Duration", send_in_pings: ["baseline"] }],
+            history: [
+              {
+                type: "timespan",
+                description: "Duration",
+                send_in_pings: ["baseline"],
+              },
+            ],
           },
         },
         "/glean/glean-core/tags": {},
@@ -499,7 +514,10 @@ describe("MCP Server library dependency resolution", () => {
       method: "tools/call",
       params: {
         name: "get_metric",
-        arguments: { app_name: "test_app", metric_name: "glean.baseline.duration" },
+        arguments: {
+          app_name: "test_app",
+          metric_name: "glean.baseline.duration",
+        },
       },
     });
 
@@ -514,7 +532,12 @@ describe("MCP Server library dependency resolution", () => {
       appMetrics: {
         "app.clicks": {
           history: [
-            { type: "counter", description: "App clicks", expires: "never", send_in_pings: ["events"] },
+            {
+              type: "counter",
+              description: "App clicks",
+              expires: "never",
+              send_in_pings: ["events"],
+            },
           ],
         },
       },
@@ -540,7 +563,10 @@ describe("MCP Server library dependency resolution", () => {
       method: "tools/call",
       params: {
         name: "get_metric",
-        arguments: { app_name: "test_app", metric_name: "glean.baseline.duration" },
+        arguments: {
+          app_name: "test_app",
+          metric_name: "glean.baseline.duration",
+        },
       },
     });
 
@@ -695,18 +721,39 @@ describe("MCP Server library dependency resolution", () => {
       ],
       appMetrics: {
         "app.clicks": {
-          history: [{ type: "counter", description: "App clicks", expires: "never", send_in_pings: ["events"] }],
+          history: [
+            {
+              type: "counter",
+              description: "App clicks",
+              expires: "never",
+              send_in_pings: ["events"],
+            },
+          ],
         },
       },
       depEndpoints: {
         "/glean/glean-core/metrics": {
           "glean.baseline.duration": {
-            history: [{ type: "timespan", description: "From glean-core", expires: "never", send_in_pings: ["baseline"] }],
+            history: [
+              {
+                type: "timespan",
+                description: "From glean-core",
+                expires: "never",
+                send_in_pings: ["baseline"],
+              },
+            ],
           },
         },
         "/glean/gecko/metrics": {
           "gecko.page.load_time": {
-            history: [{ type: "timing_distribution", description: "From gecko", expires: "never", send_in_pings: ["metrics"] }],
+            history: [
+              {
+                type: "timing_distribution",
+                description: "From gecko",
+                expires: "never",
+                send_in_pings: ["metrics"],
+              },
+            ],
           },
         },
       },
@@ -768,7 +815,14 @@ describe("MCP Server library dependency resolution", () => {
           json: () =>
             Promise.resolve({
               "app.metric": {
-                history: [{ type: "counter", description: "App metric", expires: "never", send_in_pings: ["events"] }],
+                history: [
+                  {
+                    type: "counter",
+                    description: "App metric",
+                    expires: "never",
+                    send_in_pings: ["events"],
+                  },
+                ],
               },
             }),
         });

--- a/tests/mcp.test.js
+++ b/tests/mcp.test.js
@@ -279,13 +279,14 @@ describe("MCP Server library dependency resolution", () => {
         });
       }
       // Match dependency and app endpoints: /glean/{v1_name}/{type}
-      for (const [pattern, data] of Object.entries(depEndpoints)) {
-        if (url.includes(pattern)) {
-          return Promise.resolve({
-            ok: true,
-            json: () => Promise.resolve(data),
-          });
-        }
+      const depMatch = Object.entries(depEndpoints).find(([pattern]) =>
+        url.includes(pattern)
+      );
+      if (depMatch) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(depMatch[1]),
+        });
       }
       // App's own endpoints
       if (url.includes("/glean/test-app/metrics")) {


### PR DESCRIPTION
This should fix the issue reported in https://mozilla.slack.com/archives/C07MNJ1Q3DW/p1770997453481839?thread_ts=1770294328.866299&cid=C07MNJ1Q3DW

The MCP server previously only queried an app's own probeinfo endpoints, missing metrics and pings defined by library dependencies (e.g. baseline ping from glean-core). This adds dependency resolution that fetches library-variants mappings, resolves each app's dependencies to v1 API names, and merges library data with app data.