### PR TITLE
Gracefully handle missing explores

### DIFF
--- a/etl/looker.py
+++ b/etl/looker.py
@@ -24,11 +24,7 @@ EVENT_MONITORING_DASHBOARD_URL = "https://mozilla.cloud.looker.com/dashboards/14
 
 
 def _looker_explore_exists(looker_namespaces, app_name, explore_name):
-    return (
-        looker_namespaces.get(app_name)
-        and looker_namespaces[app_name].get("glean_app")
-        and looker_namespaces[app_name]["explores"].get(explore_name)
-    )
+    return looker_namespaces.get(app_name, {}).get("explores", {}).get(explore_name)
 
 
 def _get_looker_ping_explores(


### PR DESCRIPTION
Apparently once we deprecate apps their explores are gone, as it happend for `mozilla_vpn`. And that then explodes in the explore_exists function.
I have no idea why it checks for `glean_app` though.


