### PR TITLE
update github to searchfox links

### DIFF
--- a/src/data/schemas.js
+++ b/src/data/schemas.js
@@ -5,6 +5,7 @@ import {
   getBugURL,
   getBugLinkTitle,
   getSourceUrlTitle,
+  getSourceUrl,
 } from "../formatters/links";
 import { getCodeSearchLink } from "../formatters/codesearch";
 import { getPingReasons } from "../formatters/text";
@@ -76,6 +77,7 @@ export const METRIC_DEFINITION_SCHEMA = [
     type: "link",
     helpText:
       "Where the source definition of the metric may be found (referencing the first commit in which it was introduced).",
+    linkFormatter: getSourceUrl,
     valueFormatter: getSourceUrlTitle,
   },
   {

--- a/src/formatters/links.js
+++ b/src/formatters/links.js
@@ -27,12 +27,28 @@ export function getBugLinkTitle(ref) {
   return url.replace(/^http(s?):\/\//, "");
 }
 
+export function getSourceUrl(ref) {
+  if (ref.includes("github.com/mozilla-firefox/firefox")) {
+    return ref
+      .replace(
+        "github.com/mozilla-firefox/firefox/blob/",
+        "searchfox.org/firefox-main/rev/"
+      )
+      .replace("#L", "#");
+  }
+  return ref;
+}
+
 export function getSourceUrlTitle(url) {
   if (url.includes("github.com")) {
     return url.replace(
       /[^\d]+\/([^\d]+)\/([^\d]+)\/([^\d]+)\/([^/]+)\/(.*)/,
-      (_, orgName, repoName, _blob, _hash, path) =>
-        `${orgName}/${repoName}/${path}`
+      (_, orgName, repoName, _blob, _hash, path) => {
+        if (orgName === "mozilla-firefox" && repoName === "firefox") {
+          return path.replace("#L", "#");
+        }
+        return `${orgName}/${repoName}/${path}`;
+      }
     );
   }
   return url;

--- a/tests/formatters.links.test.js
+++ b/tests/formatters.links.test.js
@@ -1,4 +1,8 @@
-import { getBugLinkTitle, getSourceUrlTitle } from "../src/formatters/links";
+import {
+  getBugLinkTitle,
+  getSourceUrl,
+  getSourceUrlTitle,
+} from "../src/formatters/links";
 
 describe("Titles for bugzilla URLs", () => {
   it("works as expected", () => {
@@ -34,6 +38,18 @@ describe("Titles for other issue tracker URLs", () => {
   });
 });
 
+describe("Links for source URL", () => {
+  it("converts github.com/mozilla-firefox/firefox links to searchfox.org links", () => {
+    expect(
+      getSourceUrl(
+        "https://github.com/mozilla-firefox/firefox/blob/b52296d542b89092ffd707ca478a85ebf0f89ff5/accessible/metrics.yaml#L14"
+      )
+    ).toBe(
+      "https://searchfox.org/firefox-main/rev/b52296d542b89092ffd707ca478a85ebf0f89ff5/accessible/metrics.yaml#14"
+    );
+  });
+});
+
 describe("Titles for source definition", () => {
   it("works as expected", () => {
     expect(
@@ -41,5 +57,13 @@ describe("Titles for source definition", () => {
         "https://github.com/mozilla-mobile/fenix/blob/b01dbeeebf2b54dabbb1b60916bee4ec2c837b5f/app/metrics.yaml#L1234"
       )
     ).toBe("mozilla-mobile/fenix/app/metrics.yaml#L1234");
+  });
+
+  it("only shows path and changes line hash for mozilla-firefox/firefox", () => {
+    expect(
+      getSourceUrlTitle(
+        "https://github.com/mozilla-firefox/firefox/blob/b52296d542b89092ffd707ca478a85ebf0f89ff5/accessible/metrics.yaml#L14"
+      )
+    ).toBe("accessible/metrics.yaml#14");
   });
 });


### PR DESCRIPTION
This PR updates github.com/mozilla-firefox/firefox metric links to go to searchfox instead.

#2279

### Pull Request checklist

<!-- Before submitting a PR for review, please address each item -->

- [ ] The pull request has a descriptive title (and a reference to an issue it
      fixes, if applicable)
- [ ] All tests and linter checks are passing
- [ ] The pull request is free of merge conflicts

<!-- For more information, see CONTRIBUTING.md at the root of this repository -->
